### PR TITLE
Debounce PeerConnectionInfoChanged

### DIFF
--- a/rust/plugin/src/godot_project.rs
+++ b/rust/plugin/src/godot_project.rs
@@ -2582,6 +2582,7 @@ impl GodotProjectImpl {
 
 				// TODO: Ask Paul about this tomorrow
 				self._sync_files_at(self.get_checked_out_branch_state().unwrap().doc_handle.clone(), files, None, None);
+				signals.push(GodotProjectSignal::FilesChanged)
 			}
         }
 


### PR DESCRIPTION
As a stopgap solution to PeerConnectionInfoChanged when other, unrelated peers edit files, debounce sending the signal back to Godot.