### PR TITLE
 fix bug where deleted binary files could not be retrieved 

### DIFF
--- a/rust/plugin/src/file_utils.rs
+++ b/rust/plugin/src/file_utils.rs
@@ -110,6 +110,9 @@ impl FileContent {
 
 	// NOTE: Probably not appropriate to put here, should have this in BranchState
 	pub fn hydrate_content_at(file_entry: ObjId, doc: &Automerge, path: &String, heads: &Vec<ChangeHash>) -> Result<FileContent, Result<DocumentId, io::Error>> {
+		if let Ok(Some((_, _))) = doc.get_at(&file_entry, "deleted", &heads) {
+			return Ok(FileContent::Deleted);
+		}
 		let structured_content = doc
 		.get_at(&file_entry, "structured_content", heads)
 		.unwrap()
@@ -118,10 +121,6 @@ impl FileContent {
 		if structured_content.is_some() {
 			let scene: GodotScene = GodotScene::hydrate_at(doc, path, heads).ok().unwrap();
 			return Ok(FileContent::Scene(scene));
-		}
-
-		if let Ok(Some((_, _))) = doc.get_at(&file_entry, "deleted", &heads) {
-			return Ok(FileContent::Deleted);
 		}
 
 		// try to read file as text


### PR DESCRIPTION
Previously, when we deleted a file, we would remove it from the "files" map in the branch doc entirely. This creates issues when you reload a project and try to revert to a commit where a deleted file was a linked binary file; since it wasn't in the "files" map, we don't retrieve the doc handle for it from the branch doc, and we have no ability to get that file. This changes it such that it retains the "url" and adds a "deleted" property to the files map if it's a binary file, so that we still see it when we retrieve the linked binary docs from the branch doc.