### PR TITLE
ci: Use godot-4.6 branches of Threadbare and Moddable Platformer

### DIFF
--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: endlessm/moddable-platformer
-          ref: main
+          ref: godot-4.6
           path: moddable-platformer
           fetch-depth: 0
           persist-credentials: false
@@ -120,7 +120,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: endlessm/threadbare
-          ref: main
+          ref: godot-4.6
           path: threadbare
           fetch-depth: 0
           lfs: true


### PR DESCRIPTION
Resolves https://github.com/inkandswitch/patchwork-godot-plugin/issues/99