### PR TITLE
Use main branches of moddable-platformer and threadbare

### DIFF
--- a/build.env
+++ b/build.env
@@ -1,8 +1,8 @@
 # Endless projects
 MODDABLE_PLATFORMER_REPO=endlessm/moddable-platformer
-MODDABLE_PLATFORMER_REF=godot-4.6
+MODDABLE_PLATFORMER_REF=main
 THREADBARE_REPO=endlessm/threadbare
-THREADBARE_REF=godot-4.6
+THREADBARE_REF=main
 
 # Godot
 GODOT_REPO=godotengine/godot.git


### PR DESCRIPTION
These projects have both been updated to Godot 4.6.

The godot-4.6 branches still exist for now but will be removed once this is merged.