### PR TITLE
ci: Remove .git/lfs/objects if present

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,13 @@ jobs:
         shell: bash
         run: |
           chmod +x ${{ matrix.artifact }}/godot_macos_editor.app/Contents/MacOS/Godot
+
+      - name: Remove Git LFS object cache
+        shell: bash
+        run: |
+          cd ${{ matrix.artifact }}
+          rm -rf .git/lfs/objects
+
       - name: Zip artifact
         run: |
           cd ${{ matrix.artifact }}


### PR DESCRIPTION
The objects in this directory are duplicates of the checked-out copies in the tree; and Git LFS will reconstitute .git/lfs/objects as needed. Removing them reduces the size of the Threadbare .zip file from 250 MB to 150 MB.

Resolves https://github.com/inkandswitch/patchwork-godot-plugin/issues/175