### PR TITLE
Make Linux and macOS launchers executable in moddable-pong bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           chmod +x ${{ matrix.artifact }}/godot_macos_editor.app/Contents/MacOS/Godot
       - name: Set chmod for launcher
-        if: matrix.artifact == 'threadbare-with-backstitch' || matrix.artifact == 'moddable-platformer-with-backstitch'
+        if: endsWith(matrix.artifact, '-with-backstitch')
         shell: bash
         run: |
           chmod a+x ${{ matrix.artifact }}/backstitch-launcher-linux


### PR DESCRIPTION
I missed this special-case when I added the moddable-pong bundle.

Rather than adding a third case, generalise it to any artifact ending with "-with-backstitch".

Resolves https://github.com/inkandswitch/backstitch/issues/219