### PR TITLE
Use correct repo for  moddable-pong bundle

### DIFF
--- a/.github/workflows/compose_projects.yml
+++ b/.github/workflows/compose_projects.yml
@@ -12,6 +12,8 @@ jobs:
       THREADBARE_REF: ${{ steps.dotenv.outputs.THREADBARE_REF }}
       MODDABLE_PLATFORMER_REPO: ${{ steps.dotenv.outputs.MODDABLE_PLATFORMER_REPO }}
       MODDABLE_PLATFORMER_REF: ${{ steps.dotenv.outputs.MODDABLE_PLATFORMER_REF }}
+      MODDABLE_PONG_REPO: ${{ steps.dotenv.outputs.MODDABLE_PONG_REPO }}
+      MODDABLE_PONG_REF: ${{ steps.dotenv.outputs.MODDABLE_PONG_REF }}
     steps:
       - uses: actions/checkout@v4
       - id: dotenv
@@ -85,4 +87,3 @@ jobs:
           path: |
             ${{ matrix.project.name }}
           if-no-files-found: error
-


### PR DESCRIPTION
I missed one more place where the environment variables have to be set. As a result the zip file contains the backstitch repo rather than moddable-pong.

I feel like there ought to be a way to simplify this, but can't see it immediately.