### PR TITLE
Improve logging verbosity

### DIFF
--- a/.github/workflows/compose_projects.yml
+++ b/.github/workflows/compose_projects.yml
@@ -17,7 +17,7 @@ jobs:
       MODDABLE_PONG_REF: ${{ steps.dotenv.outputs.MODDABLE_PONG_REF }}
       RECOMMENDED_LAUNCHER: ${{ steps.dotenv.outputs.RECOMMENDED_LAUNCHER }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - id: dotenv
         uses: falti/dotenv-action@v1.1.5
         with:

--- a/rust/src/diff/differ.rs
+++ b/rust/src/diff/differ.rs
@@ -78,7 +78,9 @@ impl Differ {
         let changed_files = self
             .branch_db
             .get_changed_files_between_refs(Some(before), after)
-            .await?;
+            .await
+            .inspect_err(|e| tracing::error!("Error during getting old_file_contents {e}"))
+            .ok()?;
 
         tracing::debug!("diffing {} changes...", changed_files.len());
 
@@ -91,11 +93,15 @@ impl Differ {
         let new_file_contents = self
             .branch_db
             .get_files_at_ref(after, &changed_filter)
-            .await?;
+            .await
+            .inspect_err(|e| tracing::error!("Error during getting new_file_contents {e}"))
+            .ok()?;
         let old_file_contents = self
             .branch_db
             .get_files_at_ref(before, &changed_filter)
-            .await?;
+            .await
+            .inspect_err(|e| tracing::error!("Error during getting old_file_contents {e}"))
+            .ok()?;
 
         let mut diffs: Vec<Diff> = vec![];
 

--- a/rust/src/project/branch_db.rs
+++ b/rust/src/project/branch_db.rs
@@ -1,8 +1,13 @@
 use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
+use automerge::AutomergeError;
+use autosurgeon::{HydrateError, ReconcileError};
 use samod::{DocHandle, DocumentId, Repo};
 use thiserror::Error;
-use tokio::sync::{Mutex, RwLock, broadcast};
+use tokio::{
+    sync::{Mutex, RwLock, broadcast, watch},
+    task::JoinError,
+};
 
 use crate::{
     helpers::{branch::BranchesMetadataDoc, history_ref::HistoryRef},
@@ -28,8 +33,36 @@ pub enum CanonicalBranchStatus {
 pub enum ShadowDocWaitError {
     #[error("the branch wasn't ingested")]
     BranchNotIngested,
-    #[error("unknown error waiting for shadow doc: {0}")]
-    Unknown(String),
+    #[error("tokio error: {0}")]
+    Watch(#[from] watch::error::RecvError),
+}
+
+#[derive(Error, Debug)]
+pub enum DbError {
+    #[error("there was no loaded metadata state")]
+    NoMetadataState,
+    #[error("there was no branch matching the id {0}")]
+    NoBranch(Box<DocumentId>),
+    #[error("the branch state of id {0} is wrong ({1})")]
+    BadBranchState(Box<DocumentId>, String),
+    #[error("bad branch document at ref {0} ({1})")]
+    BadBranchDocument(Box<HistoryRef>, String),
+    #[error("shadow doc isn't initialized")]
+    ShadowDocNotInitialized,
+    #[error("there was an issue with threading: {0}")]
+    Thread(#[from] JoinError),
+    #[error(transparent)]
+    RepoStopped(#[from] samod::Stopped),
+    #[error(transparent)]
+    Automerge(#[from] AutomergeError),
+    #[error(transparent)]
+    Hydrate(#[from] HydrateError),
+    #[error(transparent)]
+    Reconcile(#[from] ReconcileError),
+    #[error("the provided ref was invalid: {0}")]
+    InvalidRef(Box<HistoryRef>),
+    #[error("there were no provided file filters")]
+    NoFilters,
 }
 
 /// [BranchDb] is the primary data source for project data.

--- a/rust/src/project/branch_db.rs
+++ b/rust/src/project/branch_db.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
 use samod::{DocHandle, DocumentId, Repo};
+use thiserror::Error;
 use tokio::sync::{Mutex, RwLock, broadcast};
 
 use crate::{
@@ -22,9 +23,13 @@ pub enum CanonicalBranchStatus {
     BinaryDocNotFound,
     Healthy,
 }
+
+#[derive(Error, Debug)]
 pub enum ShadowDocWaitError {
+    #[error("the branch wasn't ingested")]
     BranchNotIngested,
-    Unknown,
+    #[error("unknown error waiting for shadow doc: {0}")]
+    Unknown(String),
 }
 
 /// [BranchDb] is the primary data source for project data.

--- a/rust/src/project/branch_db/branch.rs
+++ b/rust/src/project/branch_db/branch.rs
@@ -9,14 +9,14 @@ use crate::{
         branch::{BRANCH_DOC_VERSION, Branch, BranchesMetadataDoc, GodotProjectDoc},
         utils::{CommitMetadata, commit_with_metadata},
     },
-    project::branch_db::{BranchDb, HistoryRef},
+    project::branch_db::{BranchDb, DbError, HistoryRef},
 };
 
 // Methods related to branch and document management on a [BranchDb].
 impl BranchDb {
     /// Create a new metadata document, and a new main branch, and return the handle of the metadata document.
     /// Checks out the initial commit of the main branch automatically.
-    pub async fn create_metadata_doc(&self) -> DocHandle {
+    pub async fn create_metadata_doc(&self) -> Result<DocHandle, DbError> {
         tracing::info!("Creating new metadata doc...");
         let username = self.username.lock().await.clone();
 
@@ -25,7 +25,7 @@ impl BranchDb {
         let mut checked_out_ref = r.write().await;
 
         // Create new main branch doc
-        let main_handle = self.repo.create(Automerge::new()).await.unwrap();
+        let main_handle = self.repo.create(Automerge::new()).await?;
         let main_handle_clone = main_handle.clone();
         let username_clone = username.clone();
 
@@ -101,29 +101,24 @@ impl BranchDb {
                 );
             });
         })
-        .await
-        .unwrap();
-        metadata_handle_clone
+        .await?;
+        Ok(metadata_handle_clone)
     }
 
     #[tracing::instrument(skip_all, level = "trace")]
-    pub(super) async fn add_branch_to_meta(&self, branch: Branch) {
+    pub(super) async fn add_branch_to_meta(&self, branch: Branch) -> Result<(), DbError> {
         let meta_handle = {
             let meta = self.metadata_state.lock().await;
-            if meta.is_none() {
-                tracing::error!("Could not find metadata document!");
-                return;
-            }
-            meta.as_ref().unwrap().0.clone()
+            meta.as_ref().ok_or(DbError::NoMetadataState)?.0.clone()
         };
 
         let username = self.username.lock().await.clone();
         tokio::task::spawn_blocking(move || {
-            meta_handle.with_document(|d| {
-                let mut branches_metadata: BranchesMetadataDoc = hydrate(d).unwrap();
+            meta_handle.with_document(|d| -> Result<_, DbError> {
+                let mut branches_metadata: BranchesMetadataDoc = hydrate(d)?;
                 let mut tx = d.transaction();
                 branches_metadata.branches.insert(branch.id.clone(), branch);
-                let _ = reconcile(&mut tx, branches_metadata);
+                reconcile(&mut tx, branches_metadata)?;
                 commit_with_metadata(
                     tx,
                     &CommitMetadata {
@@ -135,18 +130,17 @@ impl BranchDb {
                         is_setup: Some(true),
                     },
                 );
-            });
-        });
+                Ok(())
+            })
+        })
+        .await??;
+        Ok(())
     }
 
-    async fn remove_branch_from_meta(&self, branch: DocumentId) {
+    async fn remove_branch_from_meta(&self, branch: DocumentId) -> Result<(), DbError> {
         let meta_handle = {
             let meta = self.metadata_state.lock().await;
-            if meta.is_none() {
-                tracing::error!("Could not find metadata document!");
-                return;
-            }
-            meta.as_ref().unwrap().0.clone()
+            meta.as_ref().ok_or(DbError::NoMetadataState)?.0.clone()
         };
         let branch_clone = branch.clone();
         let username = self.username.lock().await.clone();
@@ -169,32 +163,33 @@ impl BranchDb {
                 );
             });
         })
-        .await
-        .unwrap();
+        .await?;
+        Ok(())
     }
 
     // delete branch isn't fully implemented right now deletes are not propagated to the frontend
     // right now this is just useful to clean up merge preview branches
     #[tracing::instrument(skip_all, level = "trace")]
-    pub async fn delete_branch(&self, branch: &DocumentId) {
-        self.remove_branch_from_meta(branch.clone()).await;
+    pub async fn delete_branch(&self, branch: &DocumentId) -> Result<(), DbError> {
+        self.remove_branch_from_meta(branch.clone()).await
     }
 
-    async fn clone_branch(&self, branch: &DocumentId) -> Option<DocHandle> {
-        self.with_shadow_document(branch, async |d| self.repo.create(d.clone()).await.unwrap())
-            .await
-            .ok()
+    async fn clone_branch(&self, branch: &DocumentId) -> Result<DocHandle, DbError> {
+        Ok(self
+            .with_shadow_document(branch, async |d| self.repo.create(d.clone()).await)
+            .await??)
     }
 
     // TODO: This would be more versatile if we gave a HistoryRef instead of a branch.
     // That way it might work for reverts too?
-    pub async fn fork_branch(&self, name: String, source: &DocumentId) -> Option<DocumentId> {
+    pub async fn fork_branch(
+        &self,
+        name: String,
+        source: &DocumentId,
+    ) -> Result<DocumentId, DbError> {
         tracing::info!("Forking new branch {:?} from source {:?}", name, source);
 
-        let Some(latest_ref) = self.get_latest_ref_on_branch(source).await else {
-            tracing::error!("Couldn't get latest ref on source branch!");
-            return None;
-        };
+        let latest_ref = self.get_latest_ref_on_branch(source).await?;
 
         // At the instant which we clone, the new shadow document does NOT exist, but the
         // canonical document does.
@@ -211,7 +206,7 @@ impl BranchDb {
             created_by: username,
             reverted_to: None,
         })
-        .await;
-        Some(id.clone())
+        .await?;
+        Ok(id.clone())
     }
 }

--- a/rust/src/project/branch_db/branch_sync.rs
+++ b/rust/src/project/branch_db/branch_sync.rs
@@ -141,7 +141,7 @@ impl BranchDb {
         }
         rx.changed()
             .await
-            .map_err(|_| ShadowDocWaitError::Unknown)?;
+            .map_err(|e| ShadowDocWaitError::Unknown(e.to_string()))?;
 
         Ok(())
     }

--- a/rust/src/project/branch_db/branch_sync.rs
+++ b/rust/src/project/branch_db/branch_sync.rs
@@ -3,7 +3,7 @@ use std::{
     sync::Arc,
 };
 
-use automerge::{Automerge, ChangeHash};
+use automerge::{Automerge, AutomergeError, ChangeHash};
 use futures::{Stream, StreamExt};
 use samod::{DocHandle, DocumentId};
 use tokio::sync::{Mutex, RwLock, watch};
@@ -11,7 +11,7 @@ use tokio_stream::wrappers::BroadcastStream;
 
 use crate::{
     helpers::{branch::BranchesMetadataDoc, history_ref::HistoryRef},
-    project::branch_db::{BranchDb, CanonicalBranchStatus, ShadowDocWaitError},
+    project::branch_db::{BranchDb, CanonicalBranchStatus, DbError, ShadowDocWaitError},
 };
 
 #[derive(Debug)]
@@ -64,10 +64,14 @@ impl BranchDb {
         BroadcastStream::new(s).filter_map(async |f| f.ok())
     }
 
-    pub async fn get_metadata_state(&self) -> Option<(DocHandle, BranchesMetadataDoc)> {
+    pub async fn get_metadata_state(&self) -> Result<(DocHandle, BranchesMetadataDoc), DbError> {
         // This is a needlessly expensive operation; we should consider allowing reference introspection via external lockers.
         // And/or improve clone perf by reducing string usage in BranchesMetadataDoc.
-        self.metadata_state.lock().await.clone()
+        self.metadata_state
+            .lock()
+            .await
+            .clone()
+            .ok_or(DbError::NoMetadataState)
     }
 
     pub async fn set_metadata_state(&self, handle: DocHandle, state: BranchesMetadataDoc) {
@@ -139,9 +143,7 @@ impl BranchDb {
         if current {
             return Ok(());
         }
-        rx.changed()
-            .await
-            .map_err(|e| ShadowDocWaitError::Unknown(e.to_string()))?;
+        rx.changed().await?;
 
         Ok(())
     }
@@ -154,7 +156,11 @@ impl BranchDb {
         states.contains_key(id)
     }
 
-    pub async fn ingest_binary_doc(&self, id: DocumentId, handle: Option<DocHandle>) {
+    pub async fn ingest_binary_doc(
+        &self,
+        id: DocumentId,
+        handle: Option<DocHandle>,
+    ) -> Result<(), DbError> {
         tracing::debug!("Ingesting binary doc {id}...");
         let mut binary_states = self.binary_states.lock().await;
         if handle.is_none() {
@@ -181,9 +187,10 @@ impl BranchDb {
                     None => BinaryDocStatus::Failed,
                 };
                 drop(state);
-                self.try_reconcile_branch(state_arc.clone()).await;
+                self.try_reconcile_branch(state_arc.clone()).await?;
             }
         }
+        Ok(())
     }
 
     pub async fn update_branch_sync_state(
@@ -191,7 +198,7 @@ impl BranchDb {
         handle: DocHandle,
         heads: Vec<ChangeHash>,
         linked_docs: HashSet<DocumentId>,
-    ) {
+    ) -> Result<(), DbError> {
         tracing::debug!("Updating branch sync state...");
         // acquire a lock to our tracked binary states.
         // This prevents anyone from tracking binary docs until we've finished our work.
@@ -219,13 +226,14 @@ impl BranchDb {
         if Self::resolved_all_canonical_binary_docs(&state.canonical_binary_docs) {
             // no double lock allowed!
             drop(state);
-            self.try_reconcile_branch(state_arc.clone()).await;
+            self.try_reconcile_branch(state_arc.clone()).await?;
         }
 
         let _ = self.branch_change_tx.send(());
 
         // Now that we release the lock to binary_states here, whenever someone else uses ingest_binary_doc(), it will look at our states
         // and remove stuff from waiting_binary_docs when it syncs.
+        Ok(())
     }
 
     // we may need to do an unordered comparison for heads across docs
@@ -246,15 +254,18 @@ impl BranchDb {
             .all(|(_, status)| *status != BinaryDocStatus::Pending)
     }
 
-    pub(super) async fn try_reconcile_branch(&self, sync_state: Arc<Mutex<BranchSyncState>>) {
+    pub(super) async fn try_reconcile_branch(
+        &self,
+        sync_state: Arc<Mutex<BranchSyncState>>,
+    ) -> Result<(), DbError> {
         let doc_change_tx = self.branch_change_tx.clone();
-        tokio::task::spawn_blocking(move || {
+        tokio::task::spawn_blocking(move || -> Result<_, DbError> {
             // this is quite weird, but we want to be holding the state mutex this entire method.
             let mut state = sync_state.blocking_lock();
 
             if !Self::resolved_all_canonical_binary_docs(&state.canonical_binary_docs) {
                 tracing::debug!("Could not reconcile because we're still waiting on binary docs.");
-                return;
+                return Ok(());
             }
 
             // did we track any new changes coming into the canonical?
@@ -265,7 +276,7 @@ impl BranchDb {
                 {
                     // if both of those were true, we don't actually need to reconcile.
                     tracing::debug!("Could not reconcile because we're already up-to-date.");
-                    return;
+                    return Ok(());
                 }
             }
 
@@ -274,41 +285,42 @@ impl BranchDb {
             // let tracked_heads = state.last_tracked.clone();
             let handle = state.canonical_doc.clone();
 
-            let (mut state, new_heads) = handle.with_document(move |d| {
-                // First, create a fork from our heads if we don't have one
-                let shadow_doc = state
-                    .shadow_doc
-                    // TODO (Lilith): Once Alex fixes fork_at, use the other line instead
-                    // .get_or_insert_with(|| d.fork_at(&tracked_heads).unwrap());
-                    .get_or_insert_with(|| d.fork());
+            let (mut state, new_heads) =
+                handle.with_document(move |d| -> Result<_, AutomergeError> {
+                    // First, create a fork from our heads if we don't have one
+                    let shadow_doc = state
+                        .shadow_doc
+                        // TODO (Lilith): Once Alex fixes fork_at, use the other line instead
+                        // .get_or_insert_with(|| d.fork_at(&tracked_heads).unwrap());
+                        .get_or_insert_with(|| d.fork());
 
-                // First, fork at tracked heads.
-                // This is important so that if new heads have appeared with unsynced binary docs since
-                // we tried to reconcile, we don't include them.
+                    // First, fork at tracked heads.
+                    // This is important so that if new heads have appeared with unsynced binary docs since
+                    // we tried to reconcile, we don't include them.
 
-                // // TODO (Lilith): Once Alex fixes fork_at, use this code instead of merging directly...
-                // let mut fork = d.fork_at(&tracked_heads).unwrap();
+                    // // TODO (Lilith): Once Alex fixes fork_at, use this code instead of merging directly...
+                    // let mut fork = d.fork_at(&tracked_heads).unwrap();
 
-                // // Next, sync our fork with the shadow doc.
-                // let _ = fork.merge(shadow_doc).unwrap();
-                // let _ = shadow_doc.merge(&mut fork).unwrap();
+                    // // Next, sync our fork with the shadow doc.
+                    // let _ = fork.merge(shadow_doc).unwrap();
+                    // let _ = shadow_doc.merge(&mut fork).unwrap();
 
-                let _ = shadow_doc.merge(d).unwrap();
+                    let _ = shadow_doc.merge(d)?;
 
-                // Last, sync our canonical doc with the shadow doc.
-                // We need to ignore the outputted heads, because we may already have unsynced changes in the canonical doc!
-                // document_watcher will pick up on any meaningful changes here, and will handle ingestion for us.
-                let _ = d.merge(shadow_doc).unwrap();
-                (state, d.get_heads())
-            });
+                    // Last, sync our canonical doc with the shadow doc.
+                    // We need to ignore the outputted heads, because we may already have unsynced changes in the canonical doc!
+                    // document_watcher will pick up on any meaningful changes here, and will handle ingestion for us.
+                    let _ = d.merge(shadow_doc)?;
+                    Ok((state, d.get_heads()))
+                })?;
             // TODO (Lilith): Figure out a way to ignore canonical heads (use shadow heads?)
             state.last_reconciled = new_heads.clone();
             state.last_tracked = new_heads;
             tracing::debug!("Reconcile completed.");
             let _ = state.shadow_doc_init_tx.send_replace(true);
             let _ = doc_change_tx.send(());
+            Ok(())
         })
-        .await
-        .unwrap();
+        .await?
     }
 }

--- a/rust/src/project/branch_db/commit.rs
+++ b/rust/src/project/branch_db/commit.rs
@@ -205,7 +205,10 @@ impl BranchDb {
         // That's OK; once the binary doc sync finishes, it will trigger a reconcile to canonical.
         // In the mean time, we can continue committing to the shadow doc.
         drop(state);
-        self.try_reconcile_branch(state_arc.clone()).await;
+        self.try_reconcile_branch(state_arc.clone())
+            .await
+            .inspect_err(|e| tracing::error!("Error reconciling after commit: {e}"))
+            .ok();
 
         tracing::info!("Committed {} files.", count);
 

--- a/rust/src/project/branch_db/file.rs
+++ b/rust/src/project/branch_db/file.rs
@@ -12,7 +12,7 @@ use crate::{
         utils::{ChangeType, CommitMetadata, commit_with_metadata},
     },
     project::{
-        branch_db::{BranchDb, HistoryRef},
+        branch_db::{BranchDb, DbError, HistoryRef},
         fs::fs_traversal::FileSystemTraversal,
     },
 };
@@ -28,7 +28,10 @@ impl BranchDb {
     // TODO: It would be smart, here, to re-insert computed hashes if they were missing or invalid.
     // We're not doing that right now because I don't know the side effects; they could be bad.
     #[tracing::instrument(skip_all, level = "trace")]
-    pub async fn get_hash_index(&self, ref_: &HistoryRef) -> Option<HashMap<String, blake3::Hash>> {
+    pub async fn get_hash_index(
+        &self,
+        ref_: &HistoryRef,
+    ) -> Result<HashMap<String, blake3::Hash>, DbError> {
         // TODO (Lilith): Should we not use the shadow document here? The canonical might be stable,
         // but I haven't thought through the consequences of using either here.
 
@@ -42,8 +45,10 @@ impl BranchDb {
             .with_shadow_document(ref_.branch(), async move |d| {
                 let heads = ref_clone.heads();
                 let Some(files_id) = d.get_obj_id_at(ROOT, "files", heads) else {
-                    tracing::error!("files not found at ref {ref_clone}!");
-                    return None;
+                    return Err(DbError::BadBranchDocument(
+                        Box::new(ref_clone),
+                        "files not found".into(),
+                    ));
                 };
 
                 let entries: Vec<(String, ObjId)> = d
@@ -61,67 +66,64 @@ impl BranchDb {
                 // Using rayon for this, to parallelize the key retrieval from the document (not just hashing!!)
                 // Maps to a PendingHash() with either a hash value or a request to look for a linked doc for slow hashing.
                 // Also maps to a bool indicating whether to re-insert the computed hash after slow hashing (useful for old or broken docs).
-                Some(
-                    entries
-                        .into_par_iter()
-                        .filter_map(|(path, entry_id)| {
-                            // First, try and access the quick hash from the doc.
-                            let should_reinsert;
-                            if let Ok(hashes) = d.get_all_at(&entry_id, "hash", heads) {
-                                // If there are multiple hashes here, it means there are conflicts!
-                                // i.e. the hash might be totally invalid; we need to calculate it manually.
-                                if hashes.len() == 1 {
-                                    let hash = &hashes.first().unwrap().0;
-                                    if let Some(bytes) = hash.to_bytes() {
-                                        if let Ok(hash) = blake3::Hash::from_slice(bytes) {
-                                            return Some((path, (PendingHash::Hash(hash), false)));
-                                        } else {
-                                            tracing::error!("Couldn't read hash for {path}");
-                                            should_reinsert = true;
-                                        }
+                Ok(entries
+                    .into_par_iter()
+                    .filter_map(|(path, entry_id)| {
+                        // First, try and access the quick hash from the doc.
+                        let should_reinsert;
+                        if let Ok(hashes) = d.get_all_at(&entry_id, "hash", heads) {
+                            // If there are multiple hashes here, it means there are conflicts!
+                            // i.e. the hash might be totally invalid; we need to calculate it manually.
+                            if hashes.len() == 1 {
+                                let hash = &hashes.first().unwrap().0;
+                                if let Some(bytes) = hash.to_bytes() {
+                                    if let Ok(hash) = blake3::Hash::from_slice(bytes) {
+                                        return Some((path, (PendingHash::Hash(hash), false)));
                                     } else {
-                                        tracing::error!("Couldn't convert hash for {path}");
+                                        tracing::error!("Couldn't read hash for {path}");
                                         should_reinsert = true;
                                     }
-                                } else if hashes.len() > 1 {
-                                    tracing::debug!("Multiple heads found {path}");
-                                    should_reinsert = false; // don't do this, I think it's unsafe because multiple clients would thrash on it
                                 } else {
-                                    tracing::debug!("No stored hash for {path}");
+                                    tracing::error!("Couldn't convert hash for {path}");
                                     should_reinsert = true;
                                 }
+                            } else if hashes.len() > 1 {
+                                tracing::debug!("Multiple heads found {path}");
+                                should_reinsert = false; // don't do this, I think it's unsafe because multiple clients would thrash on it
                             } else {
-                                tracing::debug!("Couldn't get hashes for {path}");
-                                should_reinsert = true; // I don't think this happens but might as well
+                                tracing::debug!("No stored hash for {path}");
+                                should_reinsert = true;
                             }
+                        } else {
+                            tracing::debug!("Couldn't get hashes for {path}");
+                            should_reinsert = true; // I don't think this happens but might as well
+                        }
 
-                            // If there were any issues, fallback to the slow hash.
-                            tracing::debug!("Using slow hash for {path}");
-                            match FileContent::hydrate_content_at(entry_id, d, &path, heads) {
-                                Ok(content) => {
-                                    tracing::debug!("Done logging {path}");
-                                    Some((
-                                        path,
-                                        (PendingHash::Hash(content.to_hash()), should_reinsert),
-                                    ))
-                                }
-                                Err(res) => match res {
-                                    Ok(id) => {
-                                        tracing::debug!("Done logging {path}");
-                                        Some((path, (PendingHash::Linked(id), should_reinsert)))
-                                    }
-                                    Err(error_msg) => {
-                                        tracing::error!("error: {:?}", error_msg);
-                                        None
-                                    }
-                                },
+                        // If there were any issues, fallback to the slow hash.
+                        tracing::debug!("Using slow hash for {path}");
+                        match FileContent::hydrate_content_at(entry_id, d, &path, heads) {
+                            Ok(content) => {
+                                tracing::debug!("Done logging {path}");
+                                Some((
+                                    path,
+                                    (PendingHash::Hash(content.to_hash()), should_reinsert),
+                                ))
                             }
-                        })
-                        .collect::<HashMap<String, (PendingHash, bool)>>(),
-                )
+                            Err(res) => match res {
+                                Ok(id) => {
+                                    tracing::debug!("Done logging {path}");
+                                    Some((path, (PendingHash::Linked(id), should_reinsert)))
+                                }
+                                Err(error_msg) => {
+                                    tracing::error!("error: {:?}", error_msg);
+                                    None
+                                }
+                            },
+                        }
+                    })
+                    .collect::<HashMap<String, (PendingHash, bool)>>())
             })
-            .await
-            .ok()??;
+            .await??;
 
         // Resolve binary files
         let mut new_hashes = HashMap::new();
@@ -198,12 +200,10 @@ impl BranchDb {
             .unwrap();
         }
 
-        Some(
-            new_hashes
-                .into_iter()
-                .map(|(path, (hash, _))| (path, hash))
-                .collect(),
-        )
+        Ok(new_hashes
+            .into_iter()
+            .map(|(path, (hash, _))| (path, hash))
+            .collect())
     }
 
     /// Get a list of file operations between two points in Backstitch history.
@@ -213,11 +213,11 @@ impl BranchDb {
         &self,
         old_ref: Option<&HistoryRef>,
         new_ref: &HistoryRef,
-    ) -> Option<HashMap<String, ChangeType>> {
+    ) -> Result<HashMap<String, ChangeType>, DbError> {
         tracing::info!("Getting changes between {:?} and {:?}", new_ref, old_ref);
         if !new_ref.is_valid() {
             tracing::warn!("new ref is empty, can't get changed files");
-            return None;
+            return Err(DbError::InvalidRef(Box::new(new_ref.clone())));
         }
 
         let new_index = self.get_hash_index(new_ref).await?;
@@ -226,18 +226,16 @@ impl BranchDb {
         if old_ref.is_none() || !old_ref.unwrap().is_valid() {
             tracing::info!("old heads empty, getting ALL files on branch");
 
-            return Some(
-                new_index
-                    .into_keys()
-                    .map(|path| (path, ChangeType::Created))
-                    .collect(),
-            );
+            return Ok(new_index
+                .into_keys()
+                .map(|path| (path, ChangeType::Created))
+                .collect());
         }
 
         let old_ref = old_ref.unwrap();
         let old_index = self.get_hash_index(old_ref).await?;
 
-        Some(FileSystemTraversal::get_file_changes(old_index, new_index))
+        Ok(FileSystemTraversal::get_file_changes(old_index, new_index))
     }
 
     async fn get_linked_file(&self, doc_id: &DocumentId) -> Option<FileContent> {
@@ -269,10 +267,11 @@ impl BranchDb {
         &self,
         desired_ref: &HistoryRef,
         filters: &HashSet<String>,
-    ) -> Option<HashMap<String, FileContent>> {
+    ) -> Result<HashMap<String, FileContent>, DbError> {
         if filters.is_empty() {
             tracing::debug!("Skipping get_files_at_ref; filters empty");
-            return None;
+            // This probably shouldn't be allowed... it's a smell. It happens sometimes tho idk why exactly
+            return Err(DbError::NoFilters);
         }
         tracing::info!("Getting {:?} files at ref {:?}", filters.len(), desired_ref);
         tracing::trace!("Filters: {:?}", filters);
@@ -282,8 +281,12 @@ impl BranchDb {
         let filters = filters.clone();
         let desired_ref = desired_ref.clone();
         let (mut files, linked_doc_ids) = self
-            .with_shadow_document(desired_ref.branch(), async |doc| {
-                let files_obj_id: ObjId = doc.get_at(ROOT, "files", desired_ref.heads()).ok()??.1;
+            .with_shadow_document(desired_ref.branch(), async |doc| -> Result<_, DbError> {
+                let (_, files_obj_id) = doc
+                    .get_at(ROOT, "files", desired_ref.heads())?
+                    .ok_or_else(|| {
+                        DbError::BadBranchDocument(Box::new(desired_ref.clone()), "no files".into())
+                    })?;
                 for path in doc.keys_at(&files_obj_id, desired_ref.heads()) {
                     if !filters.contains(&path) {
                         continue;
@@ -317,10 +320,9 @@ impl BranchDb {
                         },
                     };
                 }
-                Some((files, linked_doc_ids))
+                Ok((files, linked_doc_ids))
             })
-            .await
-            .ok()??;
+            .await??;
 
         for (doc_id, path) in linked_doc_ids {
             let linked_file_content: Option<FileContent> = self.get_linked_file(&doc_id).await;
@@ -331,6 +333,6 @@ impl BranchDb {
             }
         }
 
-        return Some(files);
+        return Ok(files);
     }
 }

--- a/rust/src/project/branch_db/merge_revert.rs
+++ b/rust/src/project/branch_db/merge_revert.rs
@@ -11,7 +11,7 @@ use crate::{
         history_ref::HistoryRef,
         utils::{ChangeType, CommitMetadata, MergeMetadata, commit_with_metadata},
     },
-    project::branch_db::BranchDb,
+    project::branch_db::{BranchDb, DbError},
 };
 
 impl BranchDb {
@@ -20,7 +20,7 @@ impl BranchDb {
         &self,
         source: &DocumentId,
         target: &DocumentId,
-    ) -> Option<DocumentId> {
+    ) -> Result<DocumentId, DbError> {
         // Not getting the branch state so we don't gotta clone, honestly that was probably simpler though
         let source_name = self.get_branch_name(source).await?;
         let target_name = self.get_branch_name(target).await?;
@@ -36,16 +36,14 @@ impl BranchDb {
                 let _ = preview_doc.merge(d);
             });
         })
-        .await
-        .ok()?;
+        .await?;
 
         self.with_shadow_document(target, async |d| {
             handle_clone.with_document(|preview_doc| {
                 let _ = preview_doc.merge(d);
             });
         })
-        .await
-        .ok()?;
+        .await?;
 
         let username = self.username.lock().await.clone();
         self.add_branch_to_meta(Branch {
@@ -56,18 +54,20 @@ impl BranchDb {
             created_by: username.clone(),
             reverted_to: None,
         })
-        .await;
-        Some(handle.document_id().clone())
+        .await?;
+        Ok(handle.document_id().clone())
     }
 
-    pub async fn merge_branch(&self, source: &DocumentId, target: &DocumentId) {
-        let Some(source_state) = self.get_branch_state(source).await else {
-            return;
-        };
+    pub async fn merge_branch(
+        &self,
+        source: &DocumentId,
+        target: &DocumentId,
+    ) -> Result<(), DbError> {
+        let source_state = self.get_branch_state(source).await?;
 
         if source == target {
             tracing::error!("cannot merge branch into itself!");
-            return;
+            return Ok(());
         }
 
         self.with_shadow_document(source, async |source_doc| {
@@ -75,17 +75,15 @@ impl BranchDb {
                 let _ = target_doc.merge(source_doc);
             })
             .await
-            .unwrap();
         })
-        .await
-        .unwrap();
+        .await??;
 
         // if the branch has some merge_into we know that it's a merge preview branch
         // forked_from is the original branch of the preview branch
         let forked_from = source_state.forked_from.unwrap().branch().clone();
         let merge_metadata = if source_state.merge_into.is_some() {
             match self.get_branch_state(&forked_from).await {
-                Some(original_state) => Some(MergeMetadata {
+                Ok(original_state) => Some(MergeMetadata {
                     merged_branch_id: forked_from,
                     forked_at_heads: original_state.forked_from.unwrap().heads().clone(),
                 }),
@@ -118,32 +116,26 @@ impl BranchDb {
                     },
                 );
             })
-            .await
-            .unwrap();
+            .await?;
         }
 
         // reconcile the dummy merge commit
         let states = self.branch_sync_states.lock().await;
-        let Some(state) = states.get(target) else {
-            return;
-        };
-        self.try_reconcile_branch(state.clone()).await;
+        let state = states
+            .get(target)
+            .ok_or_else(|| DbError::NoBranch(Box::new(target.clone())))?;
+        self.try_reconcile_branch(state.clone()).await?;
+        Ok(())
     }
 
     pub async fn create_revert_preview_branch(
         &self,
         branch: &DocumentId,
         ref_: &HistoryRef,
-    ) -> Option<DocumentId> {
-        let Some(current_ref) = self.get_latest_ref_on_branch(branch).await else {
-            tracing::error!(
-                "Can't create revert preview branch; no ref on branch {}!",
-                branch
-            );
-            return None;
-        };
+    ) -> Result<DocumentId, DbError> {
+        let current_ref = self.get_latest_ref_on_branch(branch).await?;
 
-        let handle = self.repo.create(Automerge::new()).await.ok()?;
+        let handle = self.repo.create(Automerge::new()).await?;
         let handle_clone = handle.clone();
 
         self.with_shadow_document(branch, async |d| {
@@ -151,8 +143,7 @@ impl BranchDb {
                 let _ = preview_doc.merge(d);
             });
         })
-        .await
-        .ok()?;
+        .await?;
 
         let username = self.username.lock().await.clone();
         self.add_branch_to_meta(Branch {
@@ -163,7 +154,7 @@ impl BranchDb {
             created_by: username.clone(),
             reverted_to: Some(ref_.clone()),
         })
-        .await;
+        .await?;
 
         let changed_files = self
             .get_changed_files_between_refs(Some(&current_ref), ref_)
@@ -196,7 +187,7 @@ impl BranchDb {
         // We pretend there's 0 linked docs, because we're forking off a shadow doc for the preview, which had BETTER
         // not be waiting on any binary docs!!!!!
         self.update_branch_sync_state(handle.clone(), current_ref.heads().clone(), HashSet::new())
-            .await;
+            .await?;
 
         self.commit_fs_changes(
             changed_files,
@@ -206,32 +197,36 @@ impl BranchDb {
         )
         .await;
 
-        Some(handle.document_id().clone())
+        Ok(handle.document_id().clone())
     }
 
-    pub async fn confirm_revert_preview_branch(&self, preview_branch: &DocumentId) {
-        let Some(preview_state) = self.get_branch_state(preview_branch).await else {
-            tracing::error!("No revert preview state!");
-            return;
-        };
+    pub async fn confirm_revert_preview_branch(
+        &self,
+        preview_branch: &DocumentId,
+    ) -> Result<(), DbError> {
+        let preview_state = self.get_branch_state(preview_branch).await?;
 
         if preview_state.reverted_to.is_none() {
-            tracing::error!("Branch {preview_branch} is not a revert preview branch!");
-            return;
+            return Err(DbError::BadBranchState(
+                Box::new(preview_branch.clone()),
+                format!("not a revert preview branch"),
+            ));
         }
 
         let Some(target) = preview_state.forked_from else {
-            tracing::error!("Branch {preview_branch} doesn't have forked_from?!?!?!?");
-            return;
+            return Err(DbError::BadBranchState(
+                Box::new(preview_branch.clone()),
+                format!("doesn't have forked_from"),
+            ));
         };
 
         self.with_shadow_document(preview_branch, async |source_doc| {
             self.with_shadow_document(target.branch(), async |target_doc| {
-                tracing::info!("HEADS BEFORE MERGE: {:?}", target_doc.get_heads());
-                tracing::info!("PREVIEW HEADS BEFORE MERGE: {:?}", source_doc.get_heads());
+                tracing::debug!("HEADS BEFORE MERGE: {:?}", target_doc.get_heads());
+                tracing::debug!("PREVIEW HEADS BEFORE MERGE: {:?}", source_doc.get_heads());
                 let res = target_doc.merge(source_doc).unwrap();
-                tracing::info!("NEW HEADS AFTER MERGE: {:?}", res);
-                tracing::info!("NEW HEADS AFTER MERGE2: {:?}", target_doc.get_heads());
+                tracing::debug!("NEW HEADS AFTER MERGE: {:?}", res);
+                tracing::debug!("NEW HEADS AFTER MERGE2: {:?}", target_doc.get_heads());
             })
             .await
             .unwrap();
@@ -242,9 +237,10 @@ impl BranchDb {
         // Unlike merging, we don't need to make a dummy commit, because the revert already had a commit of the changed files.
         // Reconcile the merge anyways though.
         let states = self.branch_sync_states.lock().await;
-        let Some(state) = states.get(target.branch()) else {
-            return;
-        };
-        self.try_reconcile_branch(state.clone()).await;
+        let state = states
+            .get(target.branch())
+            .ok_or_else(|| DbError::NoBranch(Box::new(target.branch().clone())))?;
+        self.try_reconcile_branch(state.clone()).await?;
+        Ok(())
     }
 }

--- a/rust/src/project/branch_db/merge_revert.rs
+++ b/rust/src/project/branch_db/merge_revert.rs
@@ -209,14 +209,14 @@ impl BranchDb {
         if preview_state.reverted_to.is_none() {
             return Err(DbError::BadBranchState(
                 Box::new(preview_branch.clone()),
-                format!("not a revert preview branch"),
+                "not a revert preview branch".to_string(),
             ));
         }
 
         let Some(target) = preview_state.forked_from else {
             return Err(DbError::BadBranchState(
                 Box::new(preview_branch.clone()),
-                format!("doesn't have forked_from"),
+                "doesn't have forked_from".to_string(),
             ));
         };
 

--- a/rust/src/project/branch_db/util.rs
+++ b/rust/src/project/branch_db/util.rs
@@ -5,7 +5,7 @@ use samod::DocumentId;
 
 use crate::{
     helpers::branch::Branch,
-    project::branch_db::{BranchDb, HistoryRef},
+    project::branch_db::{BranchDb, DbError, HistoryRef},
 };
 
 // Utility methods for working with [BranchDb].
@@ -40,45 +40,41 @@ impl BranchDb {
     }
 
     /// Get the most recent ref on a given branch (on the shadow doc).
-    pub async fn get_latest_ref_on_branch(&self, branch: &DocumentId) -> Option<HistoryRef> {
-        let Ok(heads) = self
+    pub async fn get_latest_ref_on_branch(
+        &self,
+        branch: &DocumentId,
+    ) -> Result<HistoryRef, DbError> {
+        let heads = self
             .with_shadow_document(branch, async |d| d.get_heads())
-            .await
-        else {
-            return None;
-        };
-
-        Some(HistoryRef::new(branch.clone(), heads))
+            .await?;
+        Ok(HistoryRef::new(branch.clone(), heads))
     }
 
     /// Get the most recent ref on a given branch (on the canonical doc).
     pub async fn get_latest_canonical_ref_on_branch(
         &self,
         branch: &DocumentId,
-    ) -> Option<HistoryRef> {
+    ) -> Result<HistoryRef, DbError> {
         let sync_states = self.branch_sync_states.lock().await;
         let Some(state) = sync_states.get(branch).cloned() else {
             tracing::error!(
                 "Branch not found in sync states! Unable to run get_latest_canonical_ref_on_branch."
             );
-            return None;
+            return Err(DbError::NoBranch(Box::new(branch.clone())));
         };
         drop(sync_states);
 
         let st = state.lock().await;
         let handle = st.canonical_doc.clone();
-        let heads = tokio::task::spawn_blocking(move || handle.with_document(|d| d.get_heads()))
-            .await
-            .ok()?;
-        Some(HistoryRef::new(branch.clone(), heads))
+        let heads =
+            tokio::task::spawn_blocking(move || handle.with_document(|d| d.get_heads())).await?;
+        Ok(HistoryRef::new(branch.clone(), heads))
     }
 
-    pub async fn get_main_branch(&self) -> Option<DocumentId> {
-        let Some((_, metadata)) = self.get_metadata_state().await else {
-            tracing::error!("Couldn't get main branch; no metadata doc.");
-            return None;
-        };
-        Some(metadata.main_doc_id)
+    pub async fn get_main_branch(&self) -> Result<DocumentId, DbError> {
+        self.get_metadata_state()
+            .await
+            .map(|(_, meta)| meta.main_doc_id)
     }
 
     /// Check if a path should be ignored based on the provided glob patterns
@@ -101,18 +97,34 @@ impl BranchDb {
             .is_ignore()
     }
 
-    pub async fn get_branch_name(&self, id: &DocumentId) -> Option<String> {
+    pub async fn get_branch_name(&self, id: &DocumentId) -> Result<String, DbError> {
         let meta = self.metadata_state.lock().await;
-        Some(meta.as_ref()?.1.branches.get(id)?.name.clone())
+
+        Ok(meta
+            .as_ref()
+            .ok_or(DbError::NoMetadataState)?
+            .1
+            .branches
+            .get(id)
+            .ok_or_else(|| DbError::NoBranch(Box::new(id.clone())))?
+            .name
+            .clone())
     }
 
     // This is not ideal -- I'd prefer not to clone unless necessary.
     // However, we NEVER want to expose our internal BranchState mutexes.
     // That could cause deadlocks if they acquired a branch state and later tried to call any branch info method on branch_db.
     // Callers should preferentially use other getter methods.
-    pub async fn get_branch_state(&self, id: &DocumentId) -> Option<Branch> {
+    pub async fn get_branch_state(&self, id: &DocumentId) -> Result<Branch, DbError> {
         let meta = self.metadata_state.lock().await;
-        Some(meta.as_ref()?.1.branches.get(id)?.clone())
+        Ok(meta
+            .as_ref()
+            .ok_or(DbError::NoMetadataState)?
+            .1
+            .branches
+            .get(id)
+            .ok_or_else(|| DbError::NoBranch(Box::new(id.clone())))?
+            .clone())
     }
 
     /// Run a closure over a mutable reference to our Automerge shadow document for a branch.
@@ -120,21 +132,19 @@ impl BranchDb {
         &self,
         branch: &DocumentId,
         f: F,
-    ) -> Result<R, ()>
+    ) -> Result<R, DbError>
     where
         F: AsyncFnOnce(&mut Automerge) -> R,
     {
         let sync_states = self.branch_sync_states.lock().await;
         let Some(state) = sync_states.get(branch).cloned() else {
-            tracing::error!("Branch not found in sync states! Unable to run with_shadow_document.");
-            return Err(());
+            return Err(DbError::NoBranch(Box::new(branch.clone())));
         };
         // intentionally drop sync_states mutex here so that we can run nested with_shadow_document calls
         drop(sync_states);
         let mut state = state.lock().await;
         let Some(shadow_doc) = state.shadow_doc.as_mut() else {
-            tracing::error!("Shadow document not initialized!");
-            return Err(());
+            return Err(DbError::ShadowDocNotInitialized);
         };
         Ok(f(shadow_doc).await)
     }

--- a/rust/src/project/connection.rs
+++ b/rust/src/project/connection.rs
@@ -1,5 +1,5 @@
 use futures::{Stream, StreamExt};
-use samod::{BackoffConfig, DialerHandle, Repo, Url};
+use samod::{BackoffConfig, DialerHandle, Repo, Stopped, Url, tokio_io::TcpDialerError};
 use thiserror::Error;
 use tokio::select;
 use tokio_util::sync::CancellationToken;
@@ -22,19 +22,19 @@ impl Drop for RemoteConnection {
 
 #[derive(Error, Debug)]
 pub enum RemoteConnectionError {
-    #[error("unknown connection error")]
-    Unknown,
+    #[error(transparent)]
+    RepoStopped(#[from] Stopped),
+    #[error(transparent)]
+    Tcp(#[from] TcpDialerError),
 }
 
 impl RemoteConnection {
     /// Starts a connection to the server.
     pub async fn new(repo: Repo, server_url: Url) -> Result<Self, RemoteConnectionError> {
         let handle = if server_url.scheme() == "ws" || server_url.scheme() == "wss" {
-            repo.dial_websocket(server_url, BackoffConfig::default())
-                .map_err(|_| RemoteConnectionError::Unknown)?
+            repo.dial_websocket(server_url, BackoffConfig::default())?
         } else if server_url.scheme() == "tcp" {
-            repo.dial_tcp(server_url, BackoffConfig::default())
-                .map_err(|_| RemoteConnectionError::Unknown)?
+            repo.dial_tcp(server_url, BackoffConfig::default())?
         } else {
             panic!(
                 "Could not initialize server connection; the URL {server_url} has an invalid scheme (must be tcp://, ws://, or wss://)"

--- a/rust/src/project/document_watcher.rs
+++ b/rust/src/project/document_watcher.rs
@@ -35,8 +35,8 @@ pub enum IngestWaitError {
     NotTracked,
     #[error("this branch timed out when waiting for the ingest.")]
     TimedOut,
-    #[error("this branch can't be tracked by the document watcher for unknown reasons.")]
-    Unknown,
+    #[error("this branch can't be tracked by the document watcher: {0}")]
+    Unknown(String),
 }
 
 #[derive(Debug, Clone)]
@@ -99,11 +99,15 @@ impl DocumentWatcher {
         };
         let mut current = rx.borrow_and_update().clone();
         while current == BranchIngestState::Pending {
-            rx.changed().await.map_err(|_| IngestWaitError::Unknown)?;
+            rx.changed()
+                .await
+                .map_err(|e| IngestWaitError::Unknown(e.to_string()))?;
             current = rx.borrow_and_update().clone();
         }
         match current {
-            BranchIngestState::Pending => Err(IngestWaitError::Unknown), // this shouldn't happen
+            BranchIngestState::Pending => {
+                Err(IngestWaitError::Unknown("Still pending?!?".to_string()))
+            } // this shouldn't happen
             BranchIngestState::Ingested => Ok(()),
             BranchIngestState::Failed => Err(IngestWaitError::TimedOut),
         }

--- a/rust/src/project/document_watcher.rs
+++ b/rust/src/project/document_watcher.rs
@@ -35,8 +35,8 @@ pub enum IngestWaitError {
     NotTracked,
     #[error("this branch timed out when waiting for the ingest.")]
     TimedOut,
-    #[error("this branch can't be tracked by the document watcher: {0}")]
-    Unknown(String),
+    #[error("watch error: {0}")]
+    Watch(#[from] watch::error::RecvError),
 }
 
 #[derive(Debug, Clone)]
@@ -97,19 +97,16 @@ impl DocumentWatcher {
 
             tx.subscribe()
         };
-        let mut current = rx.borrow_and_update().clone();
-        while current == BranchIngestState::Pending {
-            rx.changed()
-                .await
-                .map_err(|e| IngestWaitError::Unknown(e.to_string()))?;
-            current = rx.borrow_and_update().clone();
-        }
-        match current {
-            BranchIngestState::Pending => {
-                Err(IngestWaitError::Unknown("Still pending?!?".to_string()))
-            } // this shouldn't happen
-            BranchIngestState::Ingested => Ok(()),
-            BranchIngestState::Failed => Err(IngestWaitError::TimedOut),
+
+        loop {
+            let current = rx.borrow_and_update().clone();
+            match current {
+                BranchIngestState::Pending => {
+                    rx.changed().await?;
+                }
+                BranchIngestState::Ingested => break Ok(()),
+                BranchIngestState::Failed => break Err(IngestWaitError::TimedOut),
+            }
         }
     }
 }
@@ -225,7 +222,8 @@ impl DocumentWatcherInner {
                 _ = token.cancelled() => {}
                 handle = Self::poll_document(&repo, &doc_id, poll_time, semaphore) => {
                     // this may trigger a reconciliation for a shadow doc
-                    branch_db.ingest_binary_doc(doc_id, handle).await;
+                    branch_db.ingest_binary_doc(doc_id, handle).await
+                        .inspect_err(|e| tracing::error!("Error during track_binary_document {e}")).ok();
                 }
             }
         });
@@ -280,7 +278,9 @@ impl DocumentWatcherInner {
 
         self.branch_db
             .update_branch_sync_state(handle, heads, linked_docs.values().cloned().collect())
-            .await;
+            .await
+            .inspect_err(|e| tracing::error!("Error during ingest_branch_document {e}"))
+            .ok();
     }
 
     #[tracing::instrument(skip_all, level = "trace")]

--- a/rust/src/project/driver.rs
+++ b/rust/src/project/driver.rs
@@ -7,7 +7,7 @@ use crate::project::branch_db::{BranchDb, CanonicalBranchStatus};
 use crate::project::change_ingester::ChangeIngester;
 use crate::project::connection::{RemoteConnection, RemoteConnectionError};
 use crate::project::document_watcher::{DocumentWatcher, IngestWaitError};
-use crate::project::fs::fs_index::FileSystemIndex;
+use crate::project::fs::fs_index::{FileSystemIndex, IndexError};
 use crate::project::fs::fs_traversal::FileSystemTraversal;
 use crate::project::fs::sync_automerge_to_fs::SyncAutomergeToFileSystem;
 use crate::project::fs::sync_fs_to_automerge::SyncFileSystemToAutomerge;
@@ -72,11 +72,17 @@ pub enum ProjectLoadServerStatus {
     Error,
 }
 
+#[derive(Error, Debug)]
+pub enum DriverCreateError {
+    #[error("couldn't create index: {0}")]
+    Index(#[from] IndexError),
+}
+
 /// This requires a fairly complex error type, because the overall success is dependent on whether we connect the server or not.
 #[derive(Error, Debug)]
 pub enum ProjectLoadError {
-    #[error("unknown error")]
-    Unknown,
+    #[error("unknown error {0}")]
+    Unknown(String),
     #[error("a metadata document matching the ID was not found. Server status: {server_status:?}")]
     MetadataIdNotFound {
         server_status: ProjectLoadServerStatus,
@@ -156,7 +162,7 @@ impl Driver {
             .repo
             .find(metadata_id.clone())
             .await
-            .map_err(|_| ProjectLoadError::Unknown)?
+            .map_err(|e| ProjectLoadError::Unknown(e.to_string()))?
         {
             return Ok(metadata_handle);
         }
@@ -185,7 +191,7 @@ impl Driver {
             .repo
             .find(metadata_id.clone())
             .await
-            .map_err(|_| ProjectLoadError::Unknown)?
+            .map_err(|e| ProjectLoadError::Unknown(e.to_string()))?
         {
             return Ok(metadata_handle);
         }
@@ -248,7 +254,9 @@ impl Driver {
             Some(branch) => Some(branch.clone()),
             None => self.get_main_branch().await,
         }
-        .ok_or(ProjectLoadError::Unknown)?;
+        .ok_or(ProjectLoadError::Unknown(
+            "Branch not provided, and couldn't get main branch".to_string(),
+        ))?;
 
         // Wait until we've completely finished polling the branch
         tracing::debug!("Waiting for branch to ingest...");
@@ -264,7 +272,7 @@ impl Driver {
                     tracing::error!("The provided branch document timed out while trying to get...");
                     ProjectLoadError::BranchDocNotFound { server_status: server_status.clone() }
                 },
-                IngestWaitError::Unknown => ProjectLoadError::Unknown,
+                IngestWaitError::Unknown(str) => ProjectLoadError::Unknown(str),
             })?;
 
         // The binary docs might still be screwed... so we wait for the shadow doc ingest and check the status
@@ -272,7 +280,7 @@ impl Driver {
         self.get_branch_db()
             .wait_for_shadow_doc(&branch_id)
             .await
-            .map_err(|_| ProjectLoadError::Unknown)?;
+            .map_err(|e| ProjectLoadError::Unknown(e.to_string()))?;
 
         tracing::debug!("Getting status...");
 
@@ -286,11 +294,13 @@ impl Driver {
         match status {
             CanonicalBranchStatus::Pending => {
                 tracing::error!("Branch still pending... this shouldn't happen");
-                Err(ProjectLoadError::Unknown)
+                Err(ProjectLoadError::Unknown(
+                    "Branch still pending".to_string(),
+                ))
             }
             CanonicalBranchStatus::BranchNotIngested => {
                 tracing::error!("Branch not ingested... this shouldn't happen");
-                Err(ProjectLoadError::Unknown)
+                Err(ProjectLoadError::Unknown("Branch not ingested".to_string()))
             }
             CanonicalBranchStatus::BinaryDocNotFound => {
                 tracing::error!("Giving up on load because a binary doc wasn't synced properly");
@@ -317,13 +327,17 @@ impl Driver {
             Some(branch) => Some(branch.clone()),
             None => self.get_main_branch().await,
         }
-        .ok_or(ProjectLoadError::Unknown)?;
+        .ok_or(ProjectLoadError::Unknown(
+            "Could not get main branch, and no branch was passed in".to_string(),
+        ))?;
 
         // Using canonical here means we're allowed to do this work before the shadow doc is ready (i.e. all binary docs have checked in)
         self.get_branch_db()
             .get_latest_canonical_ref_on_branch(&branch)
             .await
-            .ok_or(ProjectLoadError::Unknown)
+            .ok_or(ProjectLoadError::Unknown(
+                "Could not get latest canonical ref on branch".to_string(),
+            ))
     }
 
     pub async fn get_local_changes(
@@ -341,7 +355,7 @@ impl Driver {
             .await
             .ok_or_else(|| {
                 tracing::debug!("Couldn't get canonical file hash index!");
-                ProjectLoadError::Unknown
+                ProjectLoadError::Unknown("Couldn't get canonical file hash index!".to_string())
             })?;
         let db_clone = self.get_branch_db().clone();
         tracing::debug!("Getting current files...");
@@ -394,14 +408,12 @@ impl Driver {
     /// Creates a new instance of [Driver].
     /// Causes tasks to run in the background. To cancel everything, drop the handle.
     /// If we couldn't start the driver, [None] is returned.
-    ///
-    /// When starting the driver
     pub async fn new(
         main_thread_block: MainThreadBlock,
         project_path: PathBuf,
         username: String,
         storage_directory: PathBuf,
-    ) -> Option<Self> {
+    ) -> Result<Self, DriverCreateError> {
         let storage = samod::storage::TokioFilesystemStorage::new(&storage_directory);
         let repo = Repo::build_tokio()
             .with_concurrency(ConcurrencyConfig::Threadpool(
@@ -411,9 +423,7 @@ impl Driver {
             .load()
             .await;
 
-        let fs_index = FileSystemIndex::new(storage_directory.join("index.bin"))
-            .await
-            .ok()?;
+        let fs_index = FileSystemIndex::new(storage_directory.join("index.bin")).await?;
 
         let git_ignore: Gitignore = Self::build_gitignore(&project_path);
         let branch_db = BranchDb::new(repo.clone(), project_path, git_ignore);
@@ -441,7 +451,7 @@ impl Driver {
         let (ref_tx, _) = watch::channel(None);
         let token = CancellationToken::new();
 
-        Some(Driver {
+        Ok(Driver {
             file_changes_rx,
             inner: Arc::new(DriverInner {
                 main_thread_block,

--- a/rust/src/project/driver.rs
+++ b/rust/src/project/driver.rs
@@ -3,7 +3,7 @@ use crate::fs::file_utils::FileSystemEvent;
 use crate::helpers::history_ref::HistoryRef;
 use crate::helpers::spawn_utils::spawn_named;
 use crate::helpers::utils::{ChangeType, CommitInfo};
-use crate::project::branch_db::{BranchDb, CanonicalBranchStatus};
+use crate::project::branch_db::{BranchDb, CanonicalBranchStatus, DbError};
 use crate::project::change_ingester::ChangeIngester;
 use crate::project::connection::{RemoteConnection, RemoteConnectionError};
 use crate::project::document_watcher::{DocumentWatcher, IngestWaitError};
@@ -81,8 +81,6 @@ pub enum DriverCreateError {
 /// This requires a fairly complex error type, because the overall success is dependent on whether we connect the server or not.
 #[derive(Error, Debug)]
 pub enum ProjectLoadError {
-    #[error("unknown error {0}")]
-    Unknown(String),
     #[error("a metadata document matching the ID was not found. Server status: {server_status:?}")]
     MetadataIdNotFound {
         server_status: ProjectLoadServerStatus,
@@ -99,6 +97,15 @@ pub enum ProjectLoadError {
     BinaryDocNotFound {
         server_status: ProjectLoadServerStatus,
     },
+
+    #[error(transparent)]
+    RepoStopped(#[from] samod::Stopped),
+
+    #[error("branch db error: {0}")]
+    Db(#[from] DbError),
+
+    #[error("branch wasn't successfully ingested")]
+    NotIngested,
 }
 
 impl Drop for Driver {
@@ -158,12 +165,7 @@ impl Driver {
         //  c: The document doesn't exist at all.
 
         // First, we check the local repository. Or, if we're already connected, this also checks the remote.
-        if let Some(metadata_handle) = self
-            .repo
-            .find(metadata_id.clone())
-            .await
-            .map_err(|e| ProjectLoadError::Unknown(e.to_string()))?
-        {
+        if let Some(metadata_handle) = self.repo.find(metadata_id.clone()).await? {
             return Ok(metadata_handle);
         }
 
@@ -187,12 +189,7 @@ impl Driver {
         }
 
         // Now that we know we're connected, try the find again.
-        if let Some(metadata_handle) = self
-            .repo
-            .find(metadata_id.clone())
-            .await
-            .map_err(|e| ProjectLoadError::Unknown(e.to_string()))?
-        {
+        if let Some(metadata_handle) = self.repo.find(metadata_id.clone()).await? {
             return Ok(metadata_handle);
         }
 
@@ -251,12 +248,9 @@ impl Driver {
 
         // replace branch_id with main from metadata
         let branch_id = match branch_id {
-            Some(branch) => Some(branch.clone()),
-            None => self.get_main_branch().await,
-        }
-        .ok_or(ProjectLoadError::Unknown(
-            "Branch not provided, and couldn't get main branch".to_string(),
-        ))?;
+            Some(branch) => branch.clone(),
+            None => self.get_main_branch().await?,
+        };
 
         // Wait until we've completely finished polling the branch
         tracing::debug!("Waiting for branch to ingest...");
@@ -272,7 +266,10 @@ impl Driver {
                     tracing::error!("The provided branch document timed out while trying to get...");
                     ProjectLoadError::BranchDocNotFound { server_status: server_status.clone() }
                 },
-                IngestWaitError::Unknown(str) => ProjectLoadError::Unknown(str),
+                _ => {
+                    tracing::error!("Unknown ingest wait error {e}");
+                    ProjectLoadError::NotIngested
+                },
             })?;
 
         // The binary docs might still be screwed... so we wait for the shadow doc ingest and check the status
@@ -280,7 +277,10 @@ impl Driver {
         self.get_branch_db()
             .wait_for_shadow_doc(&branch_id)
             .await
-            .map_err(|e| ProjectLoadError::Unknown(e.to_string()))?;
+            .map_err(|e| {
+                tracing::error!("shadow doc error {e}");
+                ProjectLoadError::NotIngested
+            })?;
 
         tracing::debug!("Getting status...");
 
@@ -294,13 +294,11 @@ impl Driver {
         match status {
             CanonicalBranchStatus::Pending => {
                 tracing::error!("Branch still pending... this shouldn't happen");
-                Err(ProjectLoadError::Unknown(
-                    "Branch still pending".to_string(),
-                ))
+                Err(ProjectLoadError::NotIngested)
             }
             CanonicalBranchStatus::BranchNotIngested => {
                 tracing::error!("Branch not ingested... this shouldn't happen");
-                Err(ProjectLoadError::Unknown("Branch not ingested".to_string()))
+                Err(ProjectLoadError::NotIngested)
             }
             CanonicalBranchStatus::BinaryDocNotFound => {
                 tracing::error!("Giving up on load because a binary doc wasn't synced properly");
@@ -311,7 +309,7 @@ impl Driver {
     }
 
     pub async fn create_project(&mut self) -> Result<(), ProjectLoadError> {
-        let metadata_handle = self.inner.branch_db.create_metadata_doc().await;
+        let metadata_handle = self.inner.branch_db.create_metadata_doc().await?;
         self.create_document_watcher(&metadata_handle, 30000).await;
         // Since this is a new project (i.e. we earlier made a metadata doc), check in the files.
         // This has to go after the document watcher ingests the metadata doc, of course.
@@ -324,20 +322,15 @@ impl Driver {
         branch: Option<&DocumentId>,
     ) -> Result<HistoryRef, ProjectLoadError> {
         let branch = match branch {
-            Some(branch) => Some(branch.clone()),
-            None => self.get_main_branch().await,
-        }
-        .ok_or(ProjectLoadError::Unknown(
-            "Could not get main branch, and no branch was passed in".to_string(),
-        ))?;
+            Some(branch) => branch.clone(),
+            None => self.get_main_branch().await?,
+        };
 
         // Using canonical here means we're allowed to do this work before the shadow doc is ready (i.e. all binary docs have checked in)
-        self.get_branch_db()
+        Ok(self
+            .get_branch_db()
             .get_latest_canonical_ref_on_branch(&branch)
-            .await
-            .ok_or(ProjectLoadError::Unknown(
-                "Could not get latest canonical ref on branch".to_string(),
-            ))
+            .await?)
     }
 
     pub async fn get_local_changes(
@@ -353,10 +346,8 @@ impl Driver {
             .branch_db
             .get_hash_index(&ref_)
             .await
-            .ok_or_else(|| {
-                tracing::debug!("Couldn't get canonical file hash index!");
-                ProjectLoadError::Unknown("Couldn't get canonical file hash index!".to_string())
-            })?;
+            .inspect_err(|e| tracing::error!("Error getting canonical files: {e}"))?;
+
         let db_clone = self.get_branch_db().clone();
         tracing::debug!("Getting current files...");
         let current_files = FileSystemTraversal::get_all_files(
@@ -514,56 +505,83 @@ impl Driver {
     }
 
     pub async fn fork_branch(&self, name: String, branch: &DocumentId) {
-        if let Some(id) = self.inner.branch_db.fork_branch(name, branch).await {
-            self.request_checkout(&id).await;
+        match self.inner.branch_db.fork_branch(name, branch).await {
+            Ok(id) => {
+                self.request_checkout(&id).await;
+            }
+            Err(e) => tracing::error!("Could not fork branch: {e}"),
         }
     }
 
     pub async fn merge_branch(&self, source: &DocumentId, target: &DocumentId) {
-        self.inner.branch_db.merge_branch(source, target).await;
-        self.inner.branch_db.delete_branch(source).await;
+        match self.inner.branch_db.merge_branch(source, target).await {
+            Ok(_) => {}
+            Err(e) => tracing::error!("Could not merge branch {source} to {target}: {e}"),
+        }
+        match self.inner.branch_db.delete_branch(source).await {
+            Ok(_) => {}
+            Err(e) => {
+                tracing::error!("Could not delete merge preview branch {source}: {e}")
+            }
+        }
         self.request_checkout(target).await;
     }
 
     pub async fn discard_current_branch(&self) {
         let Some(checked_out_ref) = self.get_branch_db().get_checked_out_ref().await else {
+            tracing::error!("Could not discard current branch; no checked out ref");
             return;
         };
 
-        let Some(branch_state) = self
+        let branch_state = match self
             .get_branch_db()
             .get_branch_state(checked_out_ref.branch())
             .await
-        else {
-            return;
+        {
+            Ok(state) => state,
+            Err(e) => {
+                tracing::error!("Could not discard current branch: {e}");
+                return;
+            }
         };
 
         let Some(fork_info) = &branch_state.forked_from else {
             return;
         };
-        self.inner.branch_db.delete_branch(&branch_state.id).await;
+        match self.inner.branch_db.delete_branch(&branch_state.id).await {
+            Ok(_) => {}
+            Err(e) => tracing::error!("Error discarding current branch {e}"),
+        };
 
         self.request_checkout(fork_info.branch()).await;
     }
 
     pub async fn create_merge_preview_branch(&self, source: &DocumentId, target: &DocumentId) {
-        if let Some(id) = self
+        match self
             .inner
             .branch_db
             .create_merge_preview_branch(source, target)
             .await
         {
-            self.request_checkout(&id).await;
+            Ok(id) => {
+                self.request_checkout(&id).await;
+            }
+            Err(e) => tracing::error!(
+                "Could not create merge preview branch from {source} to {target}: {e}"
+            ),
         }
     }
 
     pub async fn create_revert_preview_branch(&self, ref_: &HistoryRef) {
-        if let Some(id) = self
+        match self
             .get_branch_db()
             .create_revert_preview_branch(ref_.branch(), ref_)
             .await
         {
-            self.request_checkout(&id).await;
+            Ok(id) => {
+                self.request_checkout(&id).await;
+            }
+            Err(e) => tracing::error!("Could not create revert preview branch: {e}"),
         }
     }
 
@@ -571,17 +589,36 @@ impl Driver {
         let Some(branch) = self.get_branch_db().get_checked_out_ref().await else {
             return;
         };
-        let Some(branch_state) = self.get_branch_db().get_branch_state(branch.branch()).await
-        else {
-            return;
+        let branch_state = match self.get_branch_db().get_branch_state(branch.branch()).await {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::error!("Could not confirm revert preview branch: {e}");
+                return;
+            }
         };
+
         let Some(forked_from) = branch_state.forked_from else {
             return;
         };
-        self.get_branch_db()
+
+        match self
+            .get_branch_db()
             .confirm_revert_preview_branch(branch.branch())
-            .await;
-        self.inner.branch_db.delete_branch(branch.branch()).await;
+            .await
+        {
+            Ok(_) => {}
+            Err(e) => {
+                tracing::error!("Could not confirm revert preview: {e}");
+                return;
+            }
+        };
+        match self.inner.branch_db.delete_branch(branch.branch()).await {
+            Ok(_) => {}
+            Err(e) => {
+                tracing::error!("Could not delete preview branch: {e}");
+                return;
+            }
+        }
         self.request_checkout(forked_from.branch()).await;
     }
 
@@ -594,20 +631,22 @@ impl Driver {
         // ProjectDiff::default()
     }
 
-    pub async fn get_metadata_doc(&self) -> Option<DocumentId> {
-        self.inner
+    pub async fn get_metadata_doc(&self) -> Result<DocumentId, ProjectLoadError> {
+        Ok(self
+            .inner
             .branch_db
             .get_metadata_state()
             .await
-            .map(|(handle, _)| handle.document_id().clone())
+            .map(|(handle, _)| handle.document_id().clone())?)
     }
 
-    pub async fn get_main_branch(&self) -> Option<DocumentId> {
-        self.inner
+    pub async fn get_main_branch(&self) -> Result<DocumentId, ProjectLoadError> {
+        Ok(self
+            .inner
             .branch_db
             .get_metadata_state()
             .await
-            .map(|(_, doc)| doc.main_doc_id)
+            .map(|(_, doc)| doc.main_doc_id)?)
     }
 
     pub async fn get_connection_info(&self) -> Option<ConnectionInfo> {
@@ -688,20 +727,22 @@ impl DriverInner {
         // If we've changed branches, send the new checked out ref.
         if let Some(ref_) = &new_checked_out_ref {
             tracing::trace!("CHECKED OUT REF: {}", ref_.branch());
-            tracing::trace!("Attepmting to sync FS to automerge...");
+            tracing::trace!("Attempting to sync FS to automerge...");
             // Apply any watched FS updates to Automerge.
             // It doesn't matter if we're safe to update Godot, so this can go outside of the guard.
             // We need to grab the most current heads in case we haven't marked them as officially checked-out yet. (I think?)
-            if let Some(current_shadow_ref) =
-                self.branch_db.get_latest_ref_on_branch(ref_.branch()).await
-            {
-                let committed_changes = self
-                    .sync_fs_to_automerge
-                    .commit(&current_shadow_ref, false)
-                    .await;
-                if !committed_changes.is_empty() {
-                    self.change_ingester.request_ingestion();
+            match self.branch_db.get_latest_ref_on_branch(ref_.branch()).await {
+                Ok(current_shadow_ref) => {
+                    let committed_changes = self
+                        .sync_fs_to_automerge
+                        .commit(&current_shadow_ref, false)
+                        .await;
+                    if !committed_changes.is_empty() {
+                        self.change_ingester.request_ingestion();
+                    }
                 }
+                // this may be overly verbose
+                Err(e) => tracing::error!("Couldn't get latest ref on branch {e}"),
             }
         } else {
             tracing::trace!("NO CHECKED OUT REF");
@@ -814,9 +855,10 @@ impl DriverInner {
         // - If we have a requested checkout that is valid, use that, and clear it
         // - If the requested checkout is invalid or empty, use the branch from the currently checked out ref
         // - If we don't have anything currently checked out, default to main.
+        // We're eating all the errors here... probably shouldn't? Idk
         let req_branch = requested_checkout.clone();
         if let Some(requested_branch) = req_branch
-            && let Some(latest) = self
+            && let Ok(latest) = self
                 .branch_db
                 .get_latest_ref_on_branch(&requested_branch)
                 .await
@@ -828,15 +870,15 @@ impl DriverInner {
         let current_ref = self.branch_db.get_checked_out_ref_mut();
         let current_ref = current_ref.read().await;
         if let Some(current_ref) = current_ref.clone()
-            && let Some(ref_) = self
+            && let Ok(ref_) = self
                 .branch_db
                 .get_latest_ref_on_branch(current_ref.branch())
                 .await
         {
             return Some(ref_);
         }
-        if let Some(main_branch) = self.branch_db.get_main_branch().await {
-            if let Some(ref_) = self.branch_db.get_latest_ref_on_branch(&main_branch).await {
+        if let Ok(main_branch) = self.branch_db.get_main_branch().await {
+            if let Ok(ref_) = self.branch_db.get_latest_ref_on_branch(&main_branch).await {
                 return Some(ref_);
             }
             tracing::error!(

--- a/rust/src/project/fs/fs_traversal.rs
+++ b/rust/src/project/fs/fs_traversal.rs
@@ -12,6 +12,7 @@ use crate::{helpers::utils::ChangeType, project::fs::fs_index::FileSystemIndex};
 pub struct FileSystemTraversal;
 
 impl FileSystemTraversal {
+    // TODO: don't throw away FS errors
     pub async fn get_all_files<P, F>(
         root: P,
         index: &FileSystemIndex,

--- a/rust/src/project/fs/sync_automerge_to_fs.rs
+++ b/rust/src/project/fs/sync_automerge_to_fs.rs
@@ -76,7 +76,6 @@ impl SyncAutomergeToFileSystem {
             .await
             .inspect_err(|e| tracing::error!(
                 "Couldn't get file content between refs; canceling ref checkout of {goal_ref:?}. Reason: {e}",
-                
             )).ok()?;
 
         let joined: HashMap<PathBuf, (ChangeType, Option<FileContent>)> = changes

--- a/rust/src/project/fs/sync_automerge_to_fs.rs
+++ b/rust/src/project/fs/sync_automerge_to_fs.rs
@@ -57,13 +57,10 @@ impl SyncAutomergeToFileSystem {
         .map(|(k, v)| (self.branch_db.localize_path(&k), v))
         .collect();
 
-        let Some(goal_files) = self.branch_db.get_hash_index(goal_ref).await else {
+        let goal_files = self.branch_db.get_hash_index(goal_ref).await.inspect_err(|e|{
             tracing::error!(
-                "Couldn't get changed file content between refs; canceling ref checkout of {:?}",
-                goal_ref
-            );
-            return None;
-        };
+                "Couldn't get changed file content between refs; canceling ref checkout of {goal_ref:?}. Reason: {e}"
+            )}).ok()?;
 
         let changes = FileSystemTraversal::get_file_changes(current_files, goal_files);
 
@@ -73,17 +70,14 @@ impl SyncAutomergeToFileSystem {
 
         tracing::debug!("Changes to be applied: {:?}", changes);
 
-        let Some(mut contents) = self
+        let mut contents = self
             .branch_db
             .get_files_at_ref(goal_ref, &changes.keys().cloned().collect())
             .await
-        else {
-            tracing::error!(
-                "Couldn't get file content between refs; canceling ref checkout of {:?}",
-                goal_ref
-            );
-            return None;
-        };
+            .inspect_err(|e| tracing::error!(
+                "Couldn't get file content between refs; canceling ref checkout of {goal_ref:?}. Reason: {e}",
+                
+            )).ok()?;
 
         let joined: HashMap<PathBuf, (ChangeType, Option<FileContent>)> = changes
             .into_iter()

--- a/rust/src/project/fs/sync_fs_to_automerge.rs
+++ b/rust/src/project/fs/sync_fs_to_automerge.rs
@@ -107,13 +107,15 @@ impl SyncFileSystemToAutomerge {
         .instrument(tracing::debug_span!("get_all_files"))
         .await;
 
-        let Some(old_files) = self
+        let Ok(old_files) = self
             .branch_db
             .get_hash_index(ref_)
             .instrument(tracing::debug_span!("get_hash_index"))
             .await
+            .inspect_err(|e| {
+                tracing::error!("Failed to get current files! Canceling commit. Reason: {e}")
+            })
         else {
-            tracing::error!("Failed to get current files!");
             return HashSet::new();
         };
 

--- a/rust/src/project/project_api.rs
+++ b/rust/src/project/project_api.rs
@@ -24,8 +24,8 @@ pub enum SyncStatus {
 
 #[derive(Error, Debug)]
 pub enum ProjectStartError {
-    #[error("unknown error")]
-    Unknown,
+    #[error("unknown error {0}")]
+    Unknown(String),
     #[error(
         "we couldn't find a document of the given ID on your computer or on the provided server"
     )]

--- a/rust/src/project/project_api.rs
+++ b/rust/src/project/project_api.rs
@@ -3,11 +3,16 @@ use std::collections::{HashMap, HashSet};
 use automerge::ChangeHash;
 use samod::DocumentId;
 use thiserror::Error;
+use tokio::task::JoinError;
 
 use crate::{
     diff::differ::ProjectDiff,
     fs::file_utils::FileContent,
     helpers::{history_ref::HistoryRef, utils::ChangedFile},
+    project::{
+        connection::RemoteConnectionError,
+        driver::{DriverCreateError, ProjectLoadError},
+    },
 };
 
 /// Represents synchronization status for a project.
@@ -24,26 +29,37 @@ pub enum SyncStatus {
 
 #[derive(Error, Debug)]
 pub enum ProjectStartError {
-    #[error("unknown error {0}")]
-    Unknown(String),
+    #[error("there wasn't a created driver")]
+    NoDriver,
+    #[error(transparent)]
+    DriverLoad(Box<ProjectLoadError>),
+    #[error(transparent)]
+    DriverCreate(#[from] DriverCreateError),
+    #[error(transparent)]
+    Connection(#[from] RemoteConnectionError),
+    #[error(transparent)]
+    Join(#[from] JoinError),
     #[error(
         "we couldn't find a document of the given ID on your computer or on the provided server"
     )]
     DocumentIdNotFound,
-
     #[error(
         "we couldn't find the referenced main branch on your computer or on the provided server"
     )]
     MainBranchNotFound,
-
     #[error(
         "the server URL {0} is invalid! It must be a url of format <scheme>://hostname.com:<port>. \
         The only supported schemes are tcp://, ws://, and wss://."
     )]
     ServerUrlInvalid(String),
-
     #[error("the document ID {0} is invalid!")]
     DocumentIdInvalid(String),
+}
+
+impl From<ProjectLoadError> for ProjectStartError {
+    fn from(value: ProjectLoadError) -> Self {
+        ProjectStartError::DriverLoad(Box::new(value))
+    }
 }
 
 /// Defines the surface for the UI layer interacting with the GodotProject core logic.

--- a/rust/src/project/project_api_impl.rs
+++ b/rust/src/project/project_api_impl.rs
@@ -64,11 +64,13 @@ impl ProjectViewModel for Project {
         let branch = self.initial_branch.clone();
         let res: Result<(), ProjectStartError> =
             self.with_driver_blocking("Checkin local changes", |driver| async move {
-                let driver = driver.as_ref().ok_or(ProjectStartError::Unknown)?;
+                let driver = driver.as_ref().ok_or(ProjectStartError::Unknown(
+                    "Could not get driver!".to_string(),
+                ))?;
                 driver
                     .commit_local_changes(branch.as_ref())
                     .await
-                    .map_err(|_| ProjectStartError::Unknown)?;
+                    .map_err(|e| ProjectStartError::Unknown(e.to_string()))?;
                 Ok(())
             });
 

--- a/rust/src/project/project_api_impl.rs
+++ b/rust/src/project/project_api_impl.rs
@@ -32,7 +32,12 @@ impl ProjectViewModel for Project {
 
     fn get_project_id(&self) -> Option<DocumentId> {
         self.with_driver_blocking("Get project ID", |driver| async move {
-            driver.as_ref()?.get_metadata_doc().await
+            driver
+                .as_ref()?
+                .get_metadata_doc()
+                .await
+                .inspect_err(|e| tracing::error!("couldn't get metadata doc ID {e}"))
+                .ok()
         })
     }
 
@@ -64,13 +69,8 @@ impl ProjectViewModel for Project {
         let branch = self.initial_branch.clone();
         let res: Result<(), ProjectStartError> =
             self.with_driver_blocking("Checkin local changes", |driver| async move {
-                let driver = driver.as_ref().ok_or(ProjectStartError::Unknown(
-                    "Could not get driver!".to_string(),
-                ))?;
-                driver
-                    .commit_local_changes(branch.as_ref())
-                    .await
-                    .map_err(|e| ProjectStartError::Unknown(e.to_string()))?;
+                let driver = driver.as_ref().ok_or(ProjectStartError::NoDriver)?;
+                driver.commit_local_changes(branch.as_ref()).await?;
                 Ok(())
             });
 
@@ -78,21 +78,21 @@ impl ProjectViewModel for Project {
         // This could turn into a discard, depending on the error. Idk what it'd be though
         match res {
             Ok(_) => {}
-            Err(_) => tracing::error!(
-                "Unknown error while checking in local changes. Proceeding with start."
+            Err(e) => tracing::error!(
+                "Unknown error while checking in local changes. Proceeding with start. {e}"
             ),
         }
 
         match self.finalize_start() {
             Ok(_) => {}
-            Err(_) => tracing::error!("Unknown error while finalizing the project start."),
+            Err(e) => tracing::error!("Unknown error while finalizing the project start: {e}"),
         }
     }
 
     fn discard_local_changes(&mut self) {
         match self.finalize_start() {
             Ok(_) => {}
-            Err(_) => tracing::error!("Unknown error while finalizing the project start."),
+            Err(e) => tracing::error!("Unknown error while finalizing the project start. {e}"),
         }
     }
     fn clear_project(&mut self) {
@@ -206,16 +206,17 @@ impl ProjectViewModel for Project {
         let merge_into = merge_info.branch().clone();
         let Some((source_branch, latest_dest_heads)) =
             self.with_driver_blocking("Is safe to merge", |driver| async move {
-                let source_branch = driver
-                    .as_ref()?
-                    .get_branch_db()
+                let branch_db = driver.as_ref()?.get_branch_db();
+                let source_branch = branch_db
                     .get_branch_state(&forked_from)
-                    .await;
-                let latest_dest_heads = driver
-                    .as_ref()?
-                    .get_branch_db()
+                    .await
+                    .inspect_err(|e| tracing::error!("Error during is_safe_to_merge {e}"))
+                    .ok()?;
+                let latest_dest_heads = branch_db
                     .get_latest_ref_on_branch(&merge_into)
-                    .await?
+                    .await
+                    .inspect_err(|e| tracing::error!("Error during is_safe_to_merge {e}"))
+                    .ok()?
                     .heads()
                     .clone();
                 Some((source_branch, latest_dest_heads))
@@ -224,11 +225,10 @@ impl ProjectViewModel for Project {
             return false;
         };
 
-        source_branch.is_some_and(|s| {
-            s.forked_from
-                .as_ref()
-                .is_some_and(|i| i.heads() == &latest_dest_heads)
-        })
+        source_branch
+            .forked_from
+            .as_ref()
+            .is_some_and(|i| i.heads() == &latest_dest_heads)
     }
 
     fn confirm_preview_branch(&mut self) {
@@ -281,7 +281,11 @@ impl ProjectViewModel for Project {
                 let branch_db = d.get_branch_db();
                 let r#ref = branch_db.get_checked_out_ref().await?;
                 // don't use checked out ref, because that might be updated too late! we care about what's synced here, not what's checked out
-                let ref_ = branch_db.get_latest_ref_on_branch(r#ref.branch()).await?;
+                let ref_ = branch_db
+                    .get_latest_ref_on_branch(r#ref.branch())
+                    .await
+                    .inspect_err(|e| tracing::error!("error during get_sync_status: {e}"))
+                    .ok()?;
                 Some((info, ref_))
             })
         else {
@@ -359,7 +363,11 @@ impl ProjectViewModel for Project {
             self.with_driver_blocking("Get branch", |driver| async move {
                 tracing::trace!("Getting branch state...");
                 let branch_db = driver.as_ref()?.get_branch_db();
-                let state = branch_db.get_branch_state(&id).await?;
+                let state = branch_db
+                    .get_branch_state(&id)
+                    .await
+                    .inspect_err(|e| tracing::error!("error getting branch: {e}"))
+                    .ok()?;
                 tracing::trace!("Getting branch children...");
                 let children = branch_db.get_branch_children(&id).await;
                 Some((state, children))
@@ -388,7 +396,12 @@ impl ProjectViewModel for Project {
 
     fn get_main_branch(&self) -> Option<impl BranchViewModel> {
         let id = self.with_driver_blocking("Get main branch", |driver| async move {
-            driver.as_ref()?.get_main_branch().await
+            driver
+                .as_ref()?
+                .get_main_branch()
+                .await
+                .inspect_err(|e| tracing::error!("Error getting main branch: {e}"))
+                .ok()
         })?;
         self.get_branch(&id)
     }
@@ -429,10 +442,16 @@ impl ProjectViewModel for Project {
 
                 let branch = branch_db.get_checked_out_ref().await?.branch().clone();
 
-                let state = branch_db.get_branch_state(&branch).await?;
+                let state = branch_db
+                    .get_branch_state(&branch)
+                    .await
+                    .inspect_err(|e| tracing::error!("Error getting branch state default diff {e}"))
+                    .ok()?;
                 let synced_heads = branch_db
                     .get_latest_ref_on_branch(&branch)
-                    .await?
+                    .await
+                    .inspect_err(|e| tracing::error!("Error getting default diff {e}"))
+                    .ok()?
                     .heads()
                     .clone();
                 Some((state, synced_heads))
@@ -542,7 +561,9 @@ impl ProjectViewModel for Project {
                 .as_ref()?
                 .get_branch_db()
                 .get_files_at_ref(&ref_, &HashSet::from_iter(vec![path.clone()]))
-                .await;
+                .await
+                .inspect_err(|e| tracing::error!("Error getting file at ref: {e}"))
+                .ok();
             files?.get(&path).cloned()
         })
     }
@@ -560,6 +581,8 @@ impl ProjectViewModel for Project {
                 .get_branch_db()
                 .get_files_at_ref(&ref_, &filters)
                 .await
+                .inspect_err(|e| tracing::error!("Error getting files at ref {e}"))
+                .ok()
         })
     }
 

--- a/rust/src/project/project_base.rs
+++ b/rust/src/project/project_base.rs
@@ -186,7 +186,9 @@ impl Project {
             }
             Err(e) => {
                 match e {
-                    ProjectLoadError::Unknown => return Err(ProjectStartError::Unknown), // this shouldn't happen
+                    ProjectLoadError::Unknown(message) => {
+                        return Err(ProjectStartError::Unknown(message));
+                    } // this shouldn't happen
                     // If anything wasn't found locally, that's OK, we want to connect first
                     ProjectLoadError::MetadataIdNotFound { server_status: _ } => match server_url {
                         Some(_) => e,
@@ -213,7 +215,9 @@ impl Project {
                 }
                 Err(e) => {
                     match e {
-                        ProjectLoadError::Unknown => return Err(ProjectStartError::Unknown), // this shouldn't happen
+                        ProjectLoadError::Unknown(message) => {
+                            return Err(ProjectStartError::Unknown(message));
+                        } // this shouldn't happen
                         // What the heck? We should've already checked this case...
                         ProjectLoadError::MetadataIdNotFound { server_status: _ } => {
                             tracing::error!(
@@ -248,7 +252,7 @@ impl Project {
         driver
             .start_connection(server_url)
             .await
-            .map_err(|_| ProjectStartError::Unknown)?;
+            .map_err(|e| ProjectStartError::Unknown(e.to_string()))?;
 
         // try again to load
         match driver.load_project(metadata_id, branch_id).await {
@@ -262,7 +266,9 @@ impl Project {
             }
             Err(e) => {
                 match e {
-                    ProjectLoadError::Unknown => return Err(ProjectStartError::Unknown), // this shouldn't happen
+                    ProjectLoadError::Unknown(message) => {
+                        return Err(ProjectStartError::Unknown(message));
+                    } // this shouldn't happen
                     ProjectLoadError::MetadataIdNotFound { server_status: _ } => {
                         return Err(ProjectStartError::DocumentIdNotFound);
                     }
@@ -294,7 +300,7 @@ impl Project {
             }
             Err(e) => {
                 match e {
-                    ProjectLoadError::Unknown => Err(ProjectStartError::Unknown), // this shouldn't happen
+                    ProjectLoadError::Unknown(message) => Err(ProjectStartError::Unknown(message)), // this shouldn't happen
                     ProjectLoadError::MetadataIdNotFound { server_status: _ } => {
                         tracing::error!(
                             "What?!?!? The metadata doc went bad when trying to load the main branch!!"
@@ -399,12 +405,11 @@ impl Project {
                 // I think it's correct to spawn this on a different task explicitly, because block_on runs the future on the current thread, not a worker thread.
                 spawn_named_on("Create driver", self.runtime.handle(), async move {
                     tracing::debug!("Creating driver...");
-                    let Some(mut driver) =
-                        Driver::new(block, project_dir, username, storage_dir).await
-                    else {
-                        tracing::error!("Could not create driver!");
-                        return Err(ProjectStartError::Unknown);
-                    };
+                    let mut driver =
+                        match Driver::new(block, project_dir, username, storage_dir).await {
+                            Ok(d) => d,
+                            Err(e) => return Err(ProjectStartError::Unknown(e.to_string())),
+                        };
 
                     // We've created the driver. Before connecting, we need to load the doc and handle local changes.
                     // If we're making a new project, we don't have to worry about that.
@@ -412,7 +417,7 @@ impl Project {
                         driver
                             .create_project()
                             .await
-                            .map_err(|_| ProjectStartError::Unknown)?;
+                            .map_err(|e| ProjectStartError::Unknown(e.to_string()))?;
                         Ok((
                             driver,
                             Default::default(),
@@ -433,9 +438,9 @@ impl Project {
                         let local_changes = driver
                             .get_local_changes(saved_branch_id.as_ref())
                             .await
-                            .map_err(|_| {
+                            .map_err(|e| {
                                 tracing::error!("Couldn't get local changes!");
-                                ProjectStartError::Unknown
+                                ProjectStartError::Unknown(e.to_string())
                             })?;
                         Ok((driver, local_changes, success))
                     }
@@ -478,7 +483,9 @@ impl Project {
         let server_url = self.server_url.clone();
         let initial_branch = self.initial_branch.take();
         let metadata = self.with_driver_blocking("Finalize start", |mut driver| async move {
-            let driver = driver.as_mut().ok_or(ProjectStartError::Unknown)?;
+            let driver = driver.as_mut().ok_or(ProjectStartError::Unknown(
+                "couldn't get driver from with_driver_blocking".to_string(),
+            ))?;
             // start the connection, if we didn't before.
             if let Some(server_url) = server_url {
                 match driver.start_connection(&server_url).await {
@@ -489,7 +496,9 @@ impl Project {
             let metadata = driver
                 .get_metadata_doc()
                 .await
-                .ok_or(ProjectStartError::Unknown)?;
+                .ok_or(ProjectStartError::Unknown(
+                    "Could not get metadata doc!".to_string(),
+                ))?;
 
             driver.start_sync(initial_branch.as_ref()).await;
             Ok(metadata)

--- a/rust/src/project/project_base.rs
+++ b/rust/src/project/project_base.rs
@@ -122,8 +122,14 @@ impl Project {
 
     pub fn clear_fs_cache(&self) {
         self.with_driver_blocking("Clear FS Cache", |driver| async move {
-            let _ = driver.as_ref().unwrap().get_fs_index().clear_cache();
-        })
+            driver
+                .as_ref()
+                .unwrap()
+                .get_fs_index()
+                .clear_cache()
+                .inspect_err(|e| tracing::error!("error clearing cache: {e}"))
+                .ok();
+        });
     }
 
     pub fn get_diff(&self, before: HistoryRef, after: HistoryRef) -> ProjectDiff {
@@ -186,9 +192,6 @@ impl Project {
             }
             Err(e) => {
                 match e {
-                    ProjectLoadError::Unknown(message) => {
-                        return Err(ProjectStartError::Unknown(message));
-                    } // this shouldn't happen
                     // If anything wasn't found locally, that's OK, we want to connect first
                     ProjectLoadError::MetadataIdNotFound { server_status: _ } => match server_url {
                         Some(_) => e,
@@ -197,6 +200,8 @@ impl Project {
                     },
                     ProjectLoadError::BranchDocNotFound { server_status: _ } => e,
                     ProjectLoadError::BinaryDocNotFound { server_status: _ } => e,
+                    // If something else happened, bad!!!
+                    _ => return Err(e.into()),
                 }
             }
         };
@@ -215,9 +220,6 @@ impl Project {
                 }
                 Err(e) => {
                     match e {
-                        ProjectLoadError::Unknown(message) => {
-                            return Err(ProjectStartError::Unknown(message));
-                        } // this shouldn't happen
                         // What the heck? We should've already checked this case...
                         ProjectLoadError::MetadataIdNotFound { server_status: _ } => {
                             tracing::error!(
@@ -243,16 +245,14 @@ impl Project {
                                 found_on_provided_branch: false,
                             });
                         }
+                        _ => return Err(e.into()),
                     }
                 }
             };
         };
 
         // try and start the connection
-        driver
-            .start_connection(server_url)
-            .await
-            .map_err(|e| ProjectStartError::Unknown(e.to_string()))?;
+        driver.start_connection(server_url).await?;
 
         // try again to load
         match driver.load_project(metadata_id, branch_id).await {
@@ -266,9 +266,6 @@ impl Project {
             }
             Err(e) => {
                 match e {
-                    ProjectLoadError::Unknown(message) => {
-                        return Err(ProjectStartError::Unknown(message));
-                    } // this shouldn't happen
                     ProjectLoadError::MetadataIdNotFound { server_status: _ } => {
                         return Err(ProjectStartError::DocumentIdNotFound);
                     }
@@ -283,6 +280,7 @@ impl Project {
                             found_on_provided_branch: true,
                         });
                     }
+                    _ => return Err(e.into()),
                 }
             }
         };
@@ -300,7 +298,6 @@ impl Project {
             }
             Err(e) => {
                 match e {
-                    ProjectLoadError::Unknown(message) => Err(ProjectStartError::Unknown(message)), // this shouldn't happen
                     ProjectLoadError::MetadataIdNotFound { server_status: _ } => {
                         tracing::error!(
                             "What?!?!? The metadata doc went bad when trying to load the main branch!!"
@@ -323,6 +320,7 @@ impl Project {
                             found_on_provided_branch: false,
                         })
                     }
+                    _ => Err(e.into()),
                 }
             }
         }
@@ -375,8 +373,8 @@ impl Project {
             {
                 Some(s) => match DocumentId::from_str(&s) {
                     Ok(id) => Some(id),
-                    Err(_) => {
-                        tracing::error!("Invalid saved branch ID! Not using.");
+                    Err(e) => {
+                        tracing::error!("Invalid saved branch ID! Not using. {e}");
                         None
                     }
                 },
@@ -399,54 +397,38 @@ impl Project {
         let server_url_clone = server_url.clone();
         tracing::debug!("Attempting to create driver...");
         let init_branch = initial_branch.clone();
-        let (driver, local_changes, load_success) = self
-            .runtime
-            .block_on(
-                // I think it's correct to spawn this on a different task explicitly, because block_on runs the future on the current thread, not a worker thread.
-                spawn_named_on("Create driver", self.runtime.handle(), async move {
-                    tracing::debug!("Creating driver...");
-                    let mut driver =
-                        match Driver::new(block, project_dir, username, storage_dir).await {
-                            Ok(d) => d,
-                            Err(e) => return Err(ProjectStartError::Unknown(e.to_string())),
-                        };
+        let (driver, local_changes, load_success) = self.runtime.block_on(
+            // I think it's correct to spawn this on a different task explicitly, because block_on runs the future on the current thread, not a worker thread.
+            spawn_named_on("Create driver", self.runtime.handle(), async move {
+                tracing::debug!("Creating driver...");
+                let mut driver = Driver::new(block, project_dir, username, storage_dir).await?;
 
-                    // We've created the driver. Before connecting, we need to load the doc and handle local changes.
-                    // If we're making a new project, we don't have to worry about that.
-                    if mode_clone == ProjectCreateMode::New {
-                        driver
-                            .create_project()
-                            .await
-                            .map_err(|e| ProjectStartError::Unknown(e.to_string()))?;
-                        Ok((
-                            driver,
-                            Default::default(),
-                            LoadSuccess {
-                                found_locally: true,
-                                found_on_provided_branch: false,
-                            },
-                        ))
-                    } else {
-                        let success = Self::try_and_retry_load(
-                            &mut driver,
-                            server_url.as_ref(),
-                            &metadata_id.unwrap(), // we know this is valid, from earlier
-                            init_branch.as_ref(),
-                        )
-                        .await?;
+                // We've created the driver. Before connecting, we need to load the doc and handle local changes.
+                // If we're making a new project, we don't have to worry about that.
+                if mode_clone == ProjectCreateMode::New {
+                    driver.create_project().await?;
+                    Ok::<_, ProjectStartError>((
+                        driver,
+                        Default::default(),
+                        LoadSuccess {
+                            found_locally: true,
+                            found_on_provided_branch: false,
+                        },
+                    ))
+                } else {
+                    let success = Self::try_and_retry_load(
+                        &mut driver,
+                        server_url.as_ref(),
+                        &metadata_id.unwrap(), // we know this is valid, from earlier
+                        init_branch.as_ref(),
+                    )
+                    .await?;
 
-                        let local_changes = driver
-                            .get_local_changes(saved_branch_id.as_ref())
-                            .await
-                            .map_err(|e| {
-                                tracing::error!("Couldn't get local changes!");
-                                ProjectStartError::Unknown(e.to_string())
-                            })?;
-                        Ok((driver, local_changes, success))
-                    }
-                }),
-            )
-            .unwrap()?;
+                    let local_changes = driver.get_local_changes(saved_branch_id.as_ref()).await?;
+                    Ok((driver, local_changes, success))
+                }
+            }),
+        )??;
 
         self.changes_rx = Some(driver.get_changes_rx());
         self.connection_info_rx = Some(driver.get_connection_info_rx());
@@ -483,9 +465,7 @@ impl Project {
         let server_url = self.server_url.clone();
         let initial_branch = self.initial_branch.take();
         let metadata = self.with_driver_blocking("Finalize start", |mut driver| async move {
-            let driver = driver.as_mut().ok_or(ProjectStartError::Unknown(
-                "couldn't get driver from with_driver_blocking".to_string(),
-            ))?;
+            let driver = driver.as_mut().ok_or(ProjectStartError::NoDriver)?;
             // start the connection, if we didn't before.
             if let Some(server_url) = server_url {
                 match driver.start_connection(&server_url).await {
@@ -493,15 +473,10 @@ impl Project {
                     Err(e) => tracing::error!("Remote connection error: {:?}", e),
                 }
             }
-            let metadata = driver
-                .get_metadata_doc()
-                .await
-                .ok_or(ProjectStartError::Unknown(
-                    "Could not get metadata doc!".to_string(),
-                ))?;
+            let metadata = driver.get_metadata_doc().await?;
 
             driver.start_sync(initial_branch.as_ref()).await;
-            Ok(metadata)
+            Ok::<_, ProjectStartError>(metadata)
         })?;
         self.local_changes = Default::default();
         BackstitchConfigAccessor::set_project_value("project_doc_id", &metadata.to_string());
@@ -521,16 +496,13 @@ impl Project {
     // common utility function within this class
     pub(super) fn get_checked_out_branch_state(&self) -> Option<Branch> {
         self.with_driver_blocking("Get checked out branch state", |driver| async move {
-            let checked_out_ref = driver
-                .as_ref()?
-                .get_branch_db()
-                .get_checked_out_ref()
-                .await?;
-            driver
-                .as_ref()?
-                .get_branch_db()
+            let branch_db = driver.as_ref()?.get_branch_db();
+            let checked_out_ref = branch_db.get_checked_out_ref().await?;
+            branch_db
                 .get_branch_state(checked_out_ref.branch())
                 .await
+                .inspect_err(|e| tracing::error!("Error getting checked out branch state: {e}"))
+                .ok()
         })
     }
 


### PR DESCRIPTION
Right now, a lot of errors are eaten by BranchDB and the Driver and similar. 

This fixes this issue by integrating actual proper Rust handling: anything fallible at the driver/branchdb layer always returns a Result with a helpful `thiserror` error if needed. Errors store inherited errors, and can log them all the way up the chain. So, as long as we print the error when we eat an error (for example in project.rs), it'll get logged to the user. 
