### PR TITLE
fix bad doc id handling

### DIFF
--- a/rust/src/diff/scene_differ.rs
+++ b/rust/src/diff/scene_differ.rs
@@ -769,13 +769,13 @@ impl Differ {
         ext_resource_ids: &mut HashSet<String>,
         sub_resource_ids: &mut HashSet<String>,
     ) {
-        for (ext_id, _) in scene.ext_resources.iter() {
+        for ext_id in scene.ext_resources.keys() {
             ext_resource_ids.insert(ext_id.clone());
         }
-        for (node_id, _) in scene.nodes.iter() {
+        for node_id in scene.nodes.keys() {
             node_ids.insert(node_id.clone());
         }
-        for (sub_id, _) in scene.sub_resources.iter() {
+        for sub_id in scene.sub_resources.keys() {
             sub_resource_ids.insert(sub_id.clone());
         }
     }

--- a/rust/src/interop/godot_project.rs
+++ b/rust/src/interop/godot_project.rs
@@ -273,9 +273,19 @@ impl GodotProject {
 
     #[func]
     fn load_project(&mut self, id: String) {
-        if let Ok(id) = DocumentId::from_str(&id)
-            && let Err(e) = self.project.load_project(&id, false)
-        {
+        let id = match DocumentId::from_str(&id) {
+            Ok(id) => id,
+            Err(e) => {
+                tracing::error!("Error regular starting {:?}", e);
+                self.base_mut().call_deferred(
+                    "emit_signal",
+                    &["create_failed".to_variant(), e.to_string().to_variant()],
+                );
+                return;
+            }
+        };
+
+        if let Err(e) = self.project.load_project(&id, false) {
             tracing::error!("Error regular starting {:?}", e);
             self.base_mut().call_deferred(
                 "emit_signal",

--- a/rust/src/interop/godot_project.rs
+++ b/rust/src/interop/godot_project.rs
@@ -56,26 +56,26 @@ fn steal_editor_node_private_reload_methods_from_dialog_signal_handlers()
             let children = gui_base.get_children();
             {
                 let disk_changed_dialog_node = children.iter_shared().find(|c| {
-                if c.get_class() == "ConfirmationDialog" {
-                    // check that one of the children is a VBoxContainer
-                    let children = c.get_children();
-                    if let Some(vbox_container) = children
-                        .iter_shared()
-                        .find(|c| c.get_class() == "VBoxContainer")
-                    {
-                        // check that one of the children is a Tree
-                        let children = vbox_container.get_children();
-                        if children
+                    if c.get_class() == "ConfirmationDialog" {
+                        // check that one of the children is a VBoxContainer
+                        let children = c.get_children();
+                        if let Some(vbox_container) = children
                             .iter_shared()
-                            .find(|c| c.get_class() == "Tree")
-                            .is_some()
+                            .find(|c| c.get_class() == "VBoxContainer")
                         {
-                            return true;
+                            // check that one of the children is a Tree
+                            let children = vbox_container.get_children();
+                            if children
+                                .iter_shared()
+                                .find(|c| c.get_class() == "Tree")
+                                .is_some()
+                            {
+                                return true;
+                            }
                         }
                     }
-                }
-                false
-            })?;
+                    false
+                })?;
                 let disk_changed_dialog =
                     match disk_changed_dialog_node.try_cast::<ConfirmationDialog>() {
                         Ok(dialog) => dialog,

--- a/rust/src/interop/godot_project.rs
+++ b/rust/src/interop/godot_project.rs
@@ -41,20 +41,21 @@ fn steal_editor_node_private_reload_methods_from_dialog_signal_handlers()
 -> Option<(Callable, Callable)> {
     // get the editor node
     let editor_file_system = EditorInterface::singleton().get_resource_filesystem();
-    let editor_node = if let Some(editor_file_system) = editor_file_system {
+    let editor_node = {
+        let editor_file_system = editor_file_system?;
         // get the parent of the editor file system, that's the editor node
         editor_file_system.get_parent()
-    } else {
-        return None;
     };
     if let Some(editor_node) = editor_node {
         // get the first Panel child of the editor node, that's the gui base
         let children = editor_node.get_children();
         // it should be the first panel
-        if let Some(gui_base) = children.iter_shared().find(|c| c.get_class() == "Panel") {
+        {
+            let gui_base = children.iter_shared().find(|c| c.get_class() == "Panel")?;
             // find the disk_changed dialog child of the gui base
             let children = gui_base.get_children();
-            if let Some(disk_changed_dialog_node) = children.iter_shared().find(|c| {
+            {
+                let disk_changed_dialog_node = children.iter_shared().find(|c| {
                 if c.get_class() == "ConfirmationDialog" {
                     // check that one of the children is a VBoxContainer
                     let children = c.get_children();
@@ -74,7 +75,7 @@ fn steal_editor_node_private_reload_methods_from_dialog_signal_handlers()
                     }
                 }
                 false
-            }) {
+            })?;
                 let disk_changed_dialog =
                     match disk_changed_dialog_node.try_cast::<ConfirmationDialog>() {
                         Ok(dialog) => dialog,
@@ -102,11 +103,7 @@ fn steal_editor_node_private_reload_methods_from_dialog_signal_handlers()
                 } else {
                     return None;
                 }
-            } else {
-                return None;
             }
-        } else {
-            return None;
         }
     }
     None

--- a/rust/src/project/branch_db/commit.rs
+++ b/rust/src/project/branch_db/commit.rs
@@ -159,7 +159,7 @@ impl BranchDb {
             let _ = tx.put(
                 &file_entry,
                 "url",
-                format!("automerge:{}", &binary_doc_handle.document_id()),
+                format!("automerge:{}", binary_doc_handle.document_id()),
             );
             let _ = tx.put(&file_entry, "hash", hash.as_bytes().to_vec());
 

--- a/rust/src/project/document_watcher.rs
+++ b/rust/src/project/document_watcher.rs
@@ -300,7 +300,7 @@ impl DocumentWatcherInner {
             .await;
         // check if there are new branches that haven't loaded yet
         let mut tracked_branches = self.tracked_branches.lock().await;
-        for (branch_id, _) in meta.branches.iter() {
+        for branch_id in meta.branches.keys() {
             if !tracked_branches.contains_key(branch_id) {
                 tracked_branches.insert(
                     branch_id.clone(),

--- a/rust/src/project/driver.rs
+++ b/rust/src/project/driver.rs
@@ -102,10 +102,16 @@ pub enum ProjectLoadError {
     RepoStopped(#[from] samod::Stopped),
 
     #[error("branch db error: {0}")]
-    Db(#[from] DbError),
+    Db(Box<DbError>),
 
     #[error("branch wasn't successfully ingested")]
     NotIngested,
+}
+
+impl From<DbError> for ProjectLoadError {
+    fn from(value: DbError) -> Self {
+        Self::Db(Box::new(value))
+    }
 }
 
 impl Drop for Driver {

--- a/rust/src/project/project_api.rs
+++ b/rust/src/project/project_api.rs
@@ -58,7 +58,7 @@ pub enum ProjectStartError {
 
 impl From<ProjectLoadError> for ProjectStartError {
     fn from(value: ProjectLoadError) -> Self {
-        ProjectStartError::DriverLoad(Box::new(value))
+        Self::DriverLoad(Box::new(value))
     }
 }
 

--- a/rust/src/project/project_api_impl.rs
+++ b/rust/src/project/project_api_impl.rs
@@ -471,7 +471,7 @@ impl ProjectViewModel for Project {
         };
 
         // generate the summary
-        
+
         let title = if self.is_merge_preview_branch_active() {
             let source_name = self
                 .get_branch(branch_state.forked_from.as_ref()?.branch())?

--- a/rust/src/project/project_api_impl.rs
+++ b/rust/src/project/project_api_impl.rs
@@ -471,34 +471,34 @@ impl ProjectViewModel for Project {
         };
 
         // generate the summary
-        let title;
-        if self.is_merge_preview_branch_active() {
+        
+        let title = if self.is_merge_preview_branch_active() {
             let source_name = self
                 .get_branch(branch_state.forked_from.as_ref()?.branch())?
                 .get_name();
             let target_name = self
                 .get_branch(branch_state.merge_into.as_ref()?.branch())?
                 .get_name();
-            title = format!("Showing changes for {} -> {}", source_name, target_name);
+            format!("Showing changes for {} -> {}", source_name, target_name)
         } else if self.is_revert_preview_branch_active() {
             let source_name = self
                 .get_branch(branch_state.forked_from.as_ref()?.branch())?
                 .get_name();
             // assume reverted_to is always just 1 hash
             let short_heads = &branch_state.reverted_to?.heads().first()?.to_string()[..7];
-            title = format!(
+            format!(
                 "Showing changes for {} reverted to {}",
                 source_name, short_heads
-            );
+            )
         } else {
             let source_name = self
                 .get_branch(branch_state.forked_from.as_ref()?.branch())?
                 .get_name();
-            title = format!(
+            format!(
                 "Showing changes from {} -> {}",
                 source_name, branch_state.name
-            );
-        }
+            )
+        };
 
         let before = HistoryRef::new(branch_state.id.clone(), heads_before.clone());
         let after = HistoryRef::new(branch_state.id.clone(), heads_after.clone());


### PR DESCRIPTION
Errors weren't being forwarded to the UI when a doc ID was garbo