### PR TITLE
Disable merge preview for empty branches

### DIFF
--- a/public/gdscript/sidebar.gd
+++ b/public/gdscript/sidebar.gd
@@ -723,6 +723,9 @@ func update_action_buttons():
 	if main_branch.id == current_branch.id:
 		merge_button.disabled = true
 		merge_button.tooltip_text = "Can't merge main, because it's the root branch."
+	elif !GodotProject.can_create_merge_preview_branch():
+		merge_button.disabled = true
+		merge_button.tooltip_text = "There's nothing to merge."
 	else:
 		var parent_branch = GodotProject.get_branch(current_branch.parent)
 		merge_button.disabled = false

--- a/rust/src/helpers/history_ref.rs
+++ b/rust/src/helpers/history_ref.rs
@@ -4,6 +4,23 @@ use samod::DocumentId;
 use serde::{Deserialize, Serialize};
 use std::{fmt::Display, str::FromStr};
 
+/// Compare Automerge heads without relying on the order returned by a document.
+pub(crate) fn heads_are_equivalent(a: &[ChangeHash], b: &[ChangeHash]) -> bool {
+    let mut a = a.to_vec();
+    let mut b = b.to_vec();
+    a.sort();
+    b.sort();
+    a == b
+}
+
+/// Return whether a branch has moved beyond the heads where it was forked.
+pub(crate) fn heads_have_changes_since(
+    fork_heads: &[ChangeHash],
+    current_heads: &[ChangeHash],
+) -> bool {
+    !heads_are_equivalent(fork_heads, current_heads)
+}
+
 /// Represents a location anywhere in Backstitch's history.
 /// Associates a branch with heads on that branch.
 #[derive(Debug, Clone, Serialize, Deserialize, Reconcile, Hydrate)]
@@ -117,5 +134,48 @@ impl FromStr for HistoryRef {
             return Err("Invalid history ref");
         }
         Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hash(byte: u8) -> ChangeHash {
+        ChangeHash::from_str(&format!("{byte:02x}").repeat(32)).unwrap()
+    }
+
+    #[test]
+    fn equivalent_heads_handle_empty_and_single_head_histories() {
+        assert!(heads_are_equivalent(&[], &[]));
+        assert!(heads_are_equivalent(&[hash(1)], &[hash(1)]));
+        assert!(!heads_are_equivalent(&[], &[hash(1)]));
+        assert!(!heads_are_equivalent(&[hash(1)], &[hash(2)]));
+    }
+
+    #[test]
+    fn equivalent_heads_ignore_multi_head_order() {
+        assert!(heads_are_equivalent(
+            &[hash(1), hash(2), hash(3)],
+            &[hash(3), hash(1), hash(2)]
+        ));
+        assert!(!heads_are_equivalent(
+            &[hash(1), hash(2), hash(3)],
+            &[hash(1), hash(2), hash(4)]
+        ));
+    }
+
+    #[test]
+    fn branch_changes_are_detected_for_single_and_multi_head_histories() {
+        assert!(!heads_have_changes_since(&[hash(1)], &[hash(1)]));
+        assert!(heads_have_changes_since(&[hash(1)], &[hash(2)]));
+        assert!(!heads_have_changes_since(
+            &[hash(1), hash(2)],
+            &[hash(2), hash(1)]
+        ));
+        assert!(heads_have_changes_since(
+            &[hash(1), hash(2)],
+            &[hash(1), hash(2), hash(3)]
+        ));
     }
 }

--- a/rust/src/project/branch_db/branch_sync.rs
+++ b/rust/src/project/branch_db/branch_sync.rs
@@ -10,7 +10,10 @@ use tokio::sync::{Mutex, RwLock, watch};
 use tokio_stream::wrappers::BroadcastStream;
 
 use crate::{
-    helpers::{branch::BranchesMetadataDoc, history_ref::HistoryRef},
+    helpers::{
+        branch::BranchesMetadataDoc,
+        history_ref::{HistoryRef, heads_are_equivalent},
+    },
     project::branch_db::{BranchDb, CanonicalBranchStatus, DbError, ShadowDocWaitError},
 };
 
@@ -236,16 +239,6 @@ impl BranchDb {
         Ok(())
     }
 
-    // we may need to do an unordered comparison for heads across docs
-    // todo: we may want to factor this out to a better Heads struct to handle correct comparison always
-    fn are_heads_equivalent(a: &[ChangeHash], b: &[ChangeHash]) -> bool {
-        let mut asorted = a.to_vec();
-        let mut bsorted = b.to_vec();
-        asorted.sort();
-        bsorted.sort();
-        asorted == bsorted
-    }
-
     fn resolved_all_canonical_binary_docs(
         binary_docs: &HashMap<DocumentId, BinaryDocStatus>,
     ) -> bool {
@@ -269,10 +262,10 @@ impl BranchDb {
             }
 
             // did we track any new changes coming into the canonical?
-            if Self::are_heads_equivalent(&state.last_reconciled, &state.last_tracked) {
+            if heads_are_equivalent(&state.last_reconciled, &state.last_tracked) {
                 // is canonical still synced up with the shadow doc?
                 if let Some(shadow_doc) = &state.shadow_doc
-                    && Self::are_heads_equivalent(&state.last_reconciled, &shadow_doc.get_heads())
+                    && heads_are_equivalent(&state.last_reconciled, &shadow_doc.get_heads())
                 {
                     // if both of those were true, we don't actually need to reconcile.
                     tracing::debug!("Could not reconcile because we're already up-to-date.");

--- a/rust/src/project/project_api_impl.rs
+++ b/rust/src/project/project_api_impl.rs
@@ -7,7 +7,7 @@ use crate::{
     diff::differ::ProjectDiff,
     fs::file_utils::FileContent,
     helpers::{
-        history_ref::HistoryRef,
+        history_ref::{HistoryRef, heads_have_changes_since},
         utils::{
             BranchWrapper, ChangedFile, CommitInfo, DiffWrapper, exact_human_readable_timestamp,
             human_readable_timestamp,
@@ -124,13 +124,36 @@ impl ProjectViewModel for Project {
         let Some(main_branch) = self.get_main_branch() else {
             return false;
         };
-        match self.get_checked_out_branch_state() {
-            Some(branch_state) => branch_state.id != main_branch.get_id(),
-            _ => false,
+        let Some(branch_state) = self.get_checked_out_branch_state() else {
+            return false;
+        };
+        if branch_state.id == main_branch.get_id() {
+            return false;
         }
+
+        let Some(forked_from) = branch_state.forked_from.as_ref() else {
+            return false;
+        };
+        let branch = branch_state.id.clone();
+        let fork_heads = forked_from.heads().clone();
+
+        self.with_driver_blocking("Check merge preview eligibility", |driver| async move {
+            let branch_db = driver.as_ref()?.get_branch_db();
+            let current_ref = branch_db
+                .get_latest_ref_on_branch(&branch)
+                .await
+                .inspect_err(|e| tracing::error!("Error getting current branch heads: {e}"))
+                .ok()?;
+            Some(heads_have_changes_since(&fork_heads, current_ref.heads()))
+        })
+        .unwrap_or(false)
     }
 
     fn create_merge_preview_branch(&mut self) {
+        if !self.can_create_merge_preview_branch() {
+            return;
+        }
+
         let Some(checked_out_branch) = self.get_checked_out_branch_state() else {
             return;
         };


### PR DESCRIPTION
## Summary

- disable merge preview when a child branch has not moved beyond its fork heads
- enforce the same eligibility check in the Rust creation path
- show a clear disabled-state tooltip in the sidebar
- compare Automerge heads as unordered sets and cover reordered multi-head histories

Fixes #259

## Testing

- `cargo fmt --all -- --check`
- `cargo test --all-targets --features ''`
- `cargo clippy --all-targets -- -D warnings`
- `RUSTFLAGS='--cfg tokio_unstable' cargo clippy --all-targets --features tokio-console -- -D warnings`
- `cargo build`
- `git diff --check`

A manual Godot launch was not available in this environment because `just` and `scons` are not installed.