### PR TITLE
Refactor GodotProject and resource loaders to prevent rebind panics 

### DIFF
--- a/rust/src/interop/backstitch_resource_loader.rs
+++ b/rust/src/interop/backstitch_resource_loader.rs
@@ -19,6 +19,7 @@ use crate::helpers::history_path::HistoryRefPath;
 use crate::helpers::history_ref::HistoryRef;
 use crate::interop::fake_importers::FakeImporter;
 use crate::interop::godot_project::GodotProject;
+use crate::project::project_api::ProjectViewModel;
 
 /// This class allows us to load resources directly from backstitch history.
 /// It is registered as a resource format loader with Godot.
@@ -48,8 +49,9 @@ impl BackstitchResourceLoader {
         &self,
         history_ref_path: &HistoryRefPath,
     ) -> Result<FileContent, Error> {
-        let Some(content) = GodotProject::get_singleton()
-            .bind()
+        let Some(content) = GodotProject::get_project_singleton()
+            .read()
+            .unwrap()
             .get_file_at_ref(&history_ref_path.path, &history_ref_path.ref_)
         else {
             return Err(Error::ERR_FILE_NOT_FOUND);
@@ -63,10 +65,14 @@ impl BackstitchResourceLoader {
         history_ref_path: &HistoryRefPath,
     ) -> Result<(FileContent, Option<FileContent>), Error> {
         let import_path = format!("{}.import", history_ref_path.path);
-        let Some(contents) = GodotProject::get_singleton().bind().get_files_at_ref(
-            &history_ref_path.ref_,
-            &HashSet::from([history_ref_path.path.clone(), import_path.clone()]),
-        ) else {
+        let Some(contents) = GodotProject::get_project_singleton()
+            .read()
+            .unwrap()
+            .get_files_at_ref(
+                &history_ref_path.ref_,
+                &HashSet::from([history_ref_path.path.clone(), import_path.clone()]),
+            )
+        else {
             return Err(Error::ERR_FILE_NOT_FOUND);
         };
         let content = contents
@@ -76,10 +82,14 @@ impl BackstitchResourceLoader {
         let import_content = contents.get(&import_path);
         let mut import_content = import_content.map(|i| i.to_owned());
         if import_content.is_none() {
-            let current_ref = GodotProject::get_singleton().bind().get_current_ref();
+            let current_ref = GodotProject::get_project_singleton()
+                .read()
+                .unwrap()
+                .get_current_ref();
             if let Some(current_ref) = current_ref {
-                import_content = GodotProject::get_singleton()
-                    .bind()
+                import_content = GodotProject::get_project_singleton()
+                    .read()
+                    .unwrap()
                     .get_file_at_ref(&import_path, &current_ref);
             }
         }

--- a/rust/src/interop/godot_project.rs
+++ b/rust/src/interop/godot_project.rs
@@ -529,7 +529,10 @@ impl GodotProject {
     }
 
     pub fn get_project_singleton() -> Arc<StdRwLock<Project>> {
-        PROJECT_SINGLETON.get().unwrap().clone()
+        PROJECT_SINGLETON
+            .get()
+            .expect("get_project_singleton: Project singleton not found (GodotProject should have been the first thing initialized in the extension??)")
+            .clone()
     }
 
     /// Only here for the sake of the plugin; use `get_project_singleton` instead if using from rust code.

--- a/rust/src/interop/godot_project.rs
+++ b/rust/src/interop/godot_project.rs
@@ -1,5 +1,4 @@
 use crate::fs::file_utils::{FileContent, FileSystemEvent};
-use crate::helpers::history_ref::HistoryRef;
 use crate::interop::godot_accessors::{BackstitchEditorAccessor, EditorFilesystemAccessor};
 use crate::interop::godot_helpers::{
     ToGodotExt, branch_view_model_to_dict, change_view_model_to_dict, diff_view_model_to_dict,
@@ -26,6 +25,10 @@ use samod::DocumentId;
 use std::collections::HashSet;
 use std::ops::DerefMut;
 use std::path::PathBuf;
+use std::sync::{
+    Arc, OnceLock, PoisonError, RwLock as StdRwLock, RwLockReadGuard as StdRwLockReadGuard,
+    RwLockWriteGuard as StdRwLockWriteGuard,
+};
 use std::{collections::HashMap, str::FromStr};
 use tracing::instrument;
 
@@ -177,12 +180,15 @@ impl PendingEditorUpdate {
 #[class(base=Node, tool)]
 pub struct GodotProject {
     base: Base<Node>,
-    project: Project,
+    project: Arc<StdRwLock<Project>>,
     pending_editor_update: PendingEditorUpdate,
     reload_project_settings_callable: Option<Callable>,
     deferred_start: i32,
     was_scanning: bool,
 }
+
+// TODO: make sure this doesn't persist across hot-reloads (hot-reloads are currently broken)
+static PROJECT_SINGLETON: OnceLock<Arc<StdRwLock<Project>>> = OnceLock::new();
 
 // new API
 /// This implementation binds as closely as possible to [GodotProjectViewModel].
@@ -200,19 +206,27 @@ impl GodotProject {
     #[signal]
     fn diff_generated(diff_id: GString, diff: VarDictionary);
 
+    fn project(&self) -> StdRwLockReadGuard<'_, Project> {
+        self.project.read().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    fn project_mut(&self) -> StdRwLockWriteGuard<'_, Project> {
+        self.project.write().unwrap_or_else(PoisonError::into_inner)
+    }
+
     #[func]
     fn has_user_name(&self) -> bool {
-        self.project.has_user_name()
+        self.project().has_user_name()
     }
 
     #[func]
     fn get_user_name(&self) -> String {
-        self.project.get_user_name()
+        self.project().get_user_name()
     }
 
     #[func]
     fn set_user_name(&self, name: String) {
-        self.project.set_user_name(name);
+        self.project().set_user_name(name);
     }
 
     #[func]
@@ -222,42 +236,42 @@ impl GodotProject {
         } else {
             Some(server)
         };
-        self.project.set_server(server)
+        self.project().set_server(server)
     }
 
     #[func]
     fn get_server(&self) -> String {
-        self.project.get_server().unwrap_or("".to_string())
+        self.project().get_server().unwrap_or("".to_string())
     }
 
     #[func]
     fn get_available_servers(&self) -> PackedStringArray {
-        self.project.get_available_servers().to_godot()
+        self.project().get_available_servers().to_godot()
     }
 
     #[func]
     fn add_server(&self, server: String) {
-        self.project.add_server(server)
+        self.project().add_server(server)
     }
 
     #[func]
     fn remove_server(&self, server: String) {
-        self.project.remove_server(server)
+        self.project().remove_server(server)
     }
 
     #[func]
     fn clear_project(&mut self) {
-        self.project.clear_project();
+        self.project_mut().clear_project();
     }
 
     #[func]
     fn has_project(&self) -> bool {
-        self.project.has_project()
+        self.project().has_project()
     }
 
     #[func]
     fn get_project_id(&self) -> String {
-        if let Some(id) = self.project.get_project_id() {
+        if let Some(id) = self.project().get_project_id() {
             return id.to_string();
         }
         "".to_string()
@@ -265,7 +279,8 @@ impl GodotProject {
 
     #[func]
     fn new_project(&mut self) {
-        if let Err(e) = self.project.new_project() {
+        let res = self.project_mut().new_project();
+        if let Err(e) = res {
             tracing::error!("Error creating {:?}", e);
             self.base_mut().call_deferred(
                 "emit_signal",
@@ -288,7 +303,8 @@ impl GodotProject {
             }
         };
 
-        if let Err(e) = self.project.load_project(&id, false) {
+        let res = self.project_mut().load_project(&id, false);
+        if let Err(e) = res {
             tracing::error!("Error regular starting {:?}", e);
             self.base_mut().call_deferred(
                 "emit_signal",
@@ -299,28 +315,28 @@ impl GodotProject {
 
     #[func]
     fn local_changes(&self) -> Variant {
-        let local_changes = self.project.local_changes();
+        let local_changes = self.project().local_changes();
         local_changes._to_variant()
     }
 
     #[func]
     fn checkin_local_changes(&mut self) {
-        self.project.checkin_local_changes();
+        self.project_mut().checkin_local_changes();
     }
 
     #[func]
     fn discard_local_changes(&mut self) {
-        self.project.discard_local_changes();
+        self.project_mut().discard_local_changes();
     }
 
     #[func]
     fn get_sync_status(&self) -> VarDictionary {
-        self.project.get_sync_status().to_godot()
+        self.project().get_sync_status().to_godot()
     }
 
     #[func]
     fn print_sync_debug(&self) {
-        self.project.print_sync_debug();
+        self.project().print_sync_debug();
     }
 
     fn branch_to_variant(&self, branch: Option<impl BranchViewModel>) -> Variant {
@@ -335,22 +351,22 @@ impl GodotProject {
         let Ok(id) = DocumentId::from_str(&id) else {
             return Variant::nil();
         };
-        self.branch_to_variant(self.project.get_branch(&id))
+        self.branch_to_variant(self.project().get_branch(&id))
     }
 
     #[func]
     fn get_main_branch(&self) -> Variant {
-        self.branch_to_variant(self.project.get_main_branch())
+        self.branch_to_variant(self.project().get_main_branch())
     }
 
     #[func]
     fn get_checked_out_branch(&self) -> Variant {
-        self.branch_to_variant(self.project.get_checked_out_branch())
+        self.branch_to_variant(self.project().get_checked_out_branch())
     }
 
     #[func]
     fn dump_current_branch(&self) {
-        self.project.dump_current_branch();
+        self.project().dump_current_branch();
     }
 
     #[func]
@@ -358,29 +374,29 @@ impl GodotProject {
         let Ok(id) = DocumentId::from_str(&id) else {
             return false;
         };
-        self.project.is_branch_loaded(&id)
+        self.project().is_branch_loaded(&id)
     }
 
     #[func]
     fn create_branch(&mut self, name: String) {
-        self.project.create_branch(name);
+        self.project_mut().create_branch(name);
     }
 
     #[func]
     fn checkout_branch(&mut self, id: String) {
         if let Ok(id) = DocumentId::from_str(&id) {
-            self.project.checkout_branch(&id);
+            self.project_mut().checkout_branch(&id);
         };
     }
 
     #[func]
     fn can_create_merge_preview_branch(&self) -> bool {
-        self.project.can_create_merge_preview_branch()
+        self.project().can_create_merge_preview_branch()
     }
 
     #[func]
     fn create_merge_preview_branch(&mut self) -> Error {
-        match self.project.create_merge_preview_branch() {
+        match self.project_mut().create_merge_preview_branch() {
             Ok(_) => Error::OK,
             Err(e) => {
                 godot_error!("Error creating merge preview branch: {e}");
@@ -396,7 +412,7 @@ impl GodotProject {
     #[func]
     fn can_create_revert_preview_branch(&self, head: String) -> bool {
         if let Ok(hash) = ChangeHash::from_str(&head) {
-            return self.project.can_create_revert_preview_branch(hash);
+            return self.project().can_create_revert_preview_branch(hash);
         }
         false
     }
@@ -407,7 +423,7 @@ impl GodotProject {
             godot_error!("Invalid hash: {head}");
             return Error::ERR_INVALID_PARAMETER;
         };
-        match self.project.create_revert_preview_branch(hash) {
+        match self.project_mut().create_revert_preview_branch(hash) {
             Ok(_) => Error::OK,
             Err(e) => {
                 godot_error!("Error creating revert preview branch: {e}");
@@ -422,32 +438,32 @@ impl GodotProject {
 
     #[func]
     fn is_revert_preview_branch_active(&self) -> bool {
-        self.project.is_revert_preview_branch_active()
+        self.project().is_revert_preview_branch_active()
     }
 
     #[func]
     fn is_merge_preview_branch_active(&self) -> bool {
-        self.project.is_merge_preview_branch_active()
+        self.project().is_merge_preview_branch_active()
     }
 
     #[func]
     fn is_safe_to_merge(&self) -> bool {
-        self.project.is_safe_to_merge()
+        self.project().is_safe_to_merge()
     }
 
     #[func]
     fn confirm_preview_branch(&mut self) {
-        self.project.confirm_preview_branch();
+        self.project_mut().confirm_preview_branch();
     }
 
     #[func]
     fn discard_preview_branch(&mut self) {
-        self.project.discard_preview_branch();
+        self.project_mut().discard_preview_branch();
     }
 
     #[func]
     fn get_branch_history(&self) -> PackedStringArray {
-        self.project.get_branch_history().to_godot()
+        self.project().get_branch_history().to_godot()
     }
 
     #[func]
@@ -455,10 +471,14 @@ impl GodotProject {
         let Ok(hash) = ChangeHash::from_str(&hash) else {
             return Variant::nil();
         };
-        let Some(change) = self.project.get_change(hash) else {
+        let Some(change) = self
+            .project()
+            .get_change(hash)
+            .map(change_view_model_to_dict)
+        else {
             return Variant::nil();
         };
-        Variant::from(change_view_model_to_dict(change))
+        Variant::from(change)
     }
 
     #[func]
@@ -467,7 +487,7 @@ impl GodotProject {
             godot_error!("Invalid hash: {hash}");
             return Variant::nil();
         };
-        match self.project.try_get_diff(hash) {
+        match self.project().try_get_diff(hash) {
             Ok(diff) => Variant::from(diff_view_model_to_dict(&diff)),
             Err(e) => {
                 Self::consume_diff_error(e);
@@ -478,7 +498,7 @@ impl GodotProject {
 
     #[func]
     fn try_get_default_diff(&self) -> Variant {
-        match self.project.try_get_default_diff() {
+        match self.project().try_get_default_diff() {
             Ok(diff) => Variant::from(diff_view_model_to_dict(&diff)),
             Err(e) => {
                 Self::consume_diff_error(e);
@@ -502,14 +522,18 @@ impl GodotProject {
 
     #[func]
     fn get_current_ref_string(&self) -> String {
-        let Some(ref_) = self.project.get_current_ref() else {
+        let Some(ref_) = self.project().get_current_ref() else {
             return "".to_string();
         };
         ref_.to_string()
     }
 
-    #[func]
-    pub fn get_singleton() -> Gd<Self> {
+    pub fn get_project_singleton() -> Arc<StdRwLock<Project>> {
+        PROJECT_SINGLETON.get().unwrap().clone()
+    }
+
+    /// Only here for the sake of the plugin; use `get_project_singleton` instead if using from rust code.
+    fn get_godot_singleton() -> Gd<Self> {
         Engine::singleton()
             .get_singleton(&StringName::from("GodotProject"))
             .unwrap()
@@ -518,7 +542,7 @@ impl GodotProject {
 
     #[func]
     pub fn clear_fs_cache(&self) {
-        self.project.clear_fs_cache();
+        self.project().clear_fs_cache();
     }
 
     pub fn safe_to_update_godot(&self) -> bool {
@@ -626,46 +650,31 @@ impl GodotProject {
             reload_project_settings_callable.call(&[]);
         }
     }
-
-    // bit of a hack to clear the diff cache when UI is loaded, to facilitate debugging
-    fn clear_diff_cache(&self) {
-        self.project.clear_diff_cache();
-    }
-
-    pub fn get_current_ref(&self) -> Option<HistoryRef> {
-        self.project.get_current_ref()
-    }
-
-    pub fn get_file_at_ref(&self, path: &str, ref_: &HistoryRef) -> Option<FileContent> {
-        self.project.get_file_at_ref(path, ref_)
-    }
-
-    pub fn get_files_at_ref(
-        &self,
-        ref_: &HistoryRef,
-        filters: &HashSet<String>,
-    ) -> Option<HashMap<String, FileContent>> {
-        self.project.get_files_at_ref(ref_, filters)
-    }
 }
 
 #[godot_api]
 impl INode for GodotProject {
     fn init(_base: Base<Node>) -> Self {
+        let project_singleton = Arc::new(StdRwLock::new(Project::new(
+            ProjectSettings::singleton()
+                .globalize_path("res://")
+                .to_string()
+                .into(),
+            // the user data dir points at "user://", which is project-specific, so take its parent (which should be `app_userdata`)
+            Os::singleton()
+                .get_user_data_dir()
+                .get_base_dir()
+                .to_string()
+                .into(),
+        )));
+        PROJECT_SINGLETON
+            .set(project_singleton.clone())
+            .unwrap_or_else(|_| {
+                panic!("initialize_project_singleton: Project singleton already exists!")
+            });
         GodotProject {
             base: _base,
-            project: Project::new(
-                ProjectSettings::singleton()
-                    .globalize_path("res://")
-                    .to_string()
-                    .into(),
-                // the user data dir points at "user://", which is project-specific, so take its parent (which should be `app_userdata`)
-                Os::singleton()
-                    .get_user_data_dir()
-                    .get_base_dir()
-                    .to_string()
-                    .into(),
-            ),
+            project: project_singleton,
             pending_editor_update: PendingEditorUpdate::default(),
             reload_project_settings_callable: None,
             deferred_start: -1,
@@ -681,7 +690,7 @@ impl INode for GodotProject {
             // if we rebase and this fails, we're going to have to do something else
             panic!("Failed to steal reload methods from dialog signal handlers");
         }
-        if self.project.get_project_doc_id().is_none() {
+        if self.project().get_project_doc_id().is_none() {
             tracing::info!("Backstitch config has no project id, not autostarting...");
             return;
         }
@@ -696,8 +705,8 @@ impl INode for GodotProject {
     }
 
     fn exit_tree(&mut self) {
-        if self.project.has_project() {
-            self.project.stop();
+        if self.project().has_project() {
+            self.project_mut().stop();
         }
         // Perform typical plugin operations here.
     }
@@ -712,22 +721,27 @@ impl INode for GodotProject {
     fn process(&mut self, _delta: f64) {
         if self.deferred_start > 0 {
             self.deferred_start -= 1;
-            if self.deferred_start == 0
-                && let Some(id) = self.project.get_project_doc_id()
-                && let Err(e) = self.project.load_project(&id, true)
-            {
-                tracing::error!("Error autostarting {:?}", e);
-                self.base_mut().call_deferred(
-                    "emit_signal",
-                    &["create_failed".to_variant(), e.to_string().to_variant()],
-                );
+            if self.deferred_start == 0 {
+                let id = self.project().get_project_doc_id();
+                if let Some(id) = id {
+                    let res = self.project_mut().load_project(&id, true);
+                    if let Err(e) = res {
+                        tracing::error!("Error autostarting {:?}", e);
+                        self.base_mut().call_deferred(
+                            "emit_signal",
+                            &["create_failed".to_variant(), e.to_string().to_variant()],
+                        );
+                    }
+                }
             }
             return;
         }
-        if !self.project.has_project() {
+        if !self.project().has_project() {
             return;
         }
-        let (updates, signals) = self.project.process(_delta, self.safe_to_update_godot());
+        let (updates, signals) = self
+            .project_mut()
+            .process(_delta, self.safe_to_update_godot());
         if !updates.is_empty() {
             self.pending_editor_update.merge(
                 self.process_godot_updates(
@@ -771,9 +785,10 @@ impl GodotProjectPlugin {
     #[func]
     fn on_reload_ui(&mut self) {
         self.ui_needs_update = true;
-        let proj = GodotProject::get_singleton();
-        let b = proj.bind();
-        b.clear_diff_cache();
+        GodotProject::get_project_singleton()
+            .read()
+            .unwrap()
+            .clear_diff_cache();
     }
 
     fn instantiate_control(&self, path: &str) -> Option<Gd<Control>> {
@@ -836,7 +851,8 @@ impl GodotProjectPlugin {
     }
 
     fn update_godot_after_source_change(&mut self) -> bool {
-        let mut proj = GodotProject::get_singleton();
+        // TODO: refactor this to use the project singleton instead
+        let mut proj = GodotProject::get_godot_singleton();
         let mut p = proj.bind_mut();
         if !p.pending_editor_update.any_changes() {
             return false;
@@ -925,7 +941,7 @@ impl IEditorPlugin for GodotProjectPlugin {
         // This is at the end because DirAccess::dir_exists_absolute locks a global mutex
         {
             // If we're already the parent of it, don't add it again
-            if let Some(parent) = GodotProject::get_singleton().get_parent()
+            if let Some(parent) = GodotProject::get_godot_singleton().get_parent()
                 && parent == self.to_gd().upcast::<Node>()
             {
                 tracing::error!(
@@ -933,7 +949,8 @@ impl IEditorPlugin for GodotProjectPlugin {
                 );
             } else {
                 self.base_mut().set_process(false);
-                self.base_mut().add_child(&GodotProject::get_singleton());
+                self.base_mut()
+                    .add_child(&GodotProject::get_godot_singleton());
                 self.base_mut().set_process(true);
             }
             self.add_sidebar();
@@ -958,7 +975,8 @@ impl IEditorPlugin for GodotProjectPlugin {
         tracing::debug!("** GodotProjectPlugin: exit_tree");
         if self.initialized {
             self.remove_sidebar();
-            self.base_mut().remove_child(&GodotProject::get_singleton());
+            self.base_mut()
+                .remove_child(&GodotProject::get_godot_singleton());
         } else {
             tracing::error!("*************** DID NOT INITIALIZE!!!!!!");
         }

--- a/rust/src/interop/godot_project.rs
+++ b/rust/src/interop/godot_project.rs
@@ -378,14 +378,14 @@ impl GodotProject {
     }
 
     #[func]
-    fn create_branch(&mut self, name: String) {
-        self.project_mut().create_branch(name);
+    fn create_branch(&self, name: String) {
+        self.project().create_branch(name);
     }
 
     #[func]
-    fn checkout_branch(&mut self, id: String) {
+    fn checkout_branch(&self, id: String) {
         if let Ok(id) = DocumentId::from_str(&id) {
-            self.project_mut().checkout_branch(&id);
+            self.project().checkout_branch(&id);
         };
     }
 
@@ -395,8 +395,8 @@ impl GodotProject {
     }
 
     #[func]
-    fn create_merge_preview_branch(&mut self) -> Error {
-        match self.project_mut().create_merge_preview_branch() {
+    fn create_merge_preview_branch(&self) -> Error {
+        match self.project().create_merge_preview_branch() {
             Ok(_) => Error::OK,
             Err(e) => {
                 godot_error!("Error creating merge preview branch: {e}");
@@ -418,12 +418,12 @@ impl GodotProject {
     }
 
     #[func]
-    fn create_revert_preview_branch(&mut self, head: String) -> Error {
+    fn create_revert_preview_branch(&self, head: String) -> Error {
         let Ok(hash) = ChangeHash::from_str(&head) else {
             godot_error!("Invalid hash: {head}");
             return Error::ERR_INVALID_PARAMETER;
         };
-        match self.project_mut().create_revert_preview_branch(hash) {
+        match self.project().create_revert_preview_branch(hash) {
             Ok(_) => Error::OK,
             Err(e) => {
                 godot_error!("Error creating revert preview branch: {e}");
@@ -452,13 +452,13 @@ impl GodotProject {
     }
 
     #[func]
-    fn confirm_preview_branch(&mut self) {
-        self.project_mut().confirm_preview_branch();
+    fn confirm_preview_branch(&self) {
+        self.project().confirm_preview_branch();
     }
 
     #[func]
-    fn discard_preview_branch(&mut self) {
-        self.project_mut().discard_preview_branch();
+    fn discard_preview_branch(&self) {
+        self.project().discard_preview_branch();
     }
 
     #[func]
@@ -898,7 +898,7 @@ impl GodotProjectPlugin {
             for script in scripts_to_reload {
                 if ResourceLoader::singleton()
                     .load_ex(&script)
-                    .cache_mode(CacheMode::IGNORE_DEEP)
+                    .cache_mode(CacheMode::IGNORE_DEEP) // IGNORE_DEEP forces the GDScriptCache to reload from disk and caches it again (you'd think they'd use `REPLACE` for that...)
                     .done()
                     .is_none()
                 {

--- a/rust/src/interop/lazy_load_token.rs
+++ b/rust/src/interop/lazy_load_token.rs
@@ -19,26 +19,26 @@ pub struct LazyLoadToken {
 #[godot_api]
 impl IResource for LazyLoadToken {
     fn init(base: Base<Resource>) -> Self {
-        Self {
-            base,
-            path: String::new(),
-            original_path: None,
-            resource: None,
-            failed: false,
-        }
+        Self::create_instance(base, String::new(), None)
     }
 }
 
 impl LazyLoadToken {
-    pub fn new(path: String, original_path: Option<String>) -> Gd<LazyLoadToken> {
-        let mut tok = Self::new_gd();
-        tok.set_path_cache(&GString::from(original_path.as_ref().unwrap_or(&path)));
-        tok.bind_mut().set_paths(path, original_path);
+    fn create_instance(base: Base<Resource>, path: String, original_path: Option<String>) -> Self {
+        let mut tok = Self {
+            base,
+            path,
+            original_path,
+            resource: None,
+            failed: false,
+        };
+        if !tok.path.is_empty() {
+            tok.start_load();
+        }
         tok
     }
-    fn set_paths(&mut self, path: String, original_path: Option<String>) {
-        self.path = path;
-        self.original_path = original_path;
+    pub fn new(path: String, original_path: Option<String>) -> Gd<LazyLoadToken> {
+        Gd::from_init_fn(|base| Self::create_instance(base, path, original_path))
     }
 }
 

--- a/rust/src/project/project_api.rs
+++ b/rust/src/project/project_api.rs
@@ -157,9 +157,9 @@ pub trait ProjectViewModel {
     /// Gets the [BranchViewModel] for the current checked out branch, or [None] if we have no project.
     fn get_checked_out_branch(&self) -> Option<impl BranchViewModel>;
     /// Create a new branch, forked off the current branch with the given name.
-    fn create_branch(&mut self, branch_name: String);
+    fn create_branch(&self, branch_name: String);
     /// Check out a branch by ID.
-    fn checkout_branch(&mut self, branch: &DocumentId);
+    fn checkout_branch(&self, branch: &DocumentId);
     /// Returns true if the branch is loaded (i.e. has all of its binary docs synced).
     fn is_branch_loaded(&self, branch: &DocumentId) -> bool;
     /// Dumps a binary representation of the current branch to ./.backstitch/.
@@ -168,12 +168,12 @@ pub trait ProjectViewModel {
     /// Whether we can begin a merge preview for the current branch into its direct ancestor.
     fn can_create_merge_preview_branch(&self) -> bool;
     /// Create a new merge preview branch, for merging the current branch into its direct ancestor.
-    fn create_merge_preview_branch(&mut self) -> Result<(), CreateMergePreviewBranchError>;
+    fn create_merge_preview_branch(&self) -> Result<(), CreateMergePreviewBranchError>;
     /// Whether we can create a revert preview branch for the given head.
     fn can_create_revert_preview_branch(&self, head: ChangeHash) -> bool;
     /// Create a new revert preview branch for the given head.
     fn create_revert_preview_branch(
-        &mut self,
+        &self,
         head: ChangeHash,
     ) -> Result<(), CreateRevertPreviewBranchError>;
     /// Whether there is currently a revert preview active.
@@ -183,9 +183,9 @@ pub trait ProjectViewModel {
     /// Whether there has been changes in the root branch since we forked.
     fn is_safe_to_merge(&self) -> bool;
     /// Confirm the active preview branch, reverting or merging as necessary.
-    fn confirm_preview_branch(&mut self);
+    fn confirm_preview_branch(&self);
     /// Discard the active preview branch.
-    fn discard_preview_branch(&mut self);
+    fn discard_preview_branch(&self);
 
     /// Get the full history for the currently checked-out branch, in chronological order.
     fn get_branch_history(&self) -> Vec<ChangeHash>;

--- a/rust/src/project/project_api_impl.rs
+++ b/rust/src/project/project_api_impl.rs
@@ -132,7 +132,7 @@ impl ProjectViewModel for Project {
         }
     }
 
-    fn create_merge_preview_branch(&mut self) -> Result<(), CreateMergePreviewBranchError> {
+    fn create_merge_preview_branch(&self) -> Result<(), CreateMergePreviewBranchError> {
         let Some(checked_out_branch) = self.get_checked_out_branch_state() else {
             return Err(CreateMergePreviewBranchError::NoCheckedOutBranch);
         };
@@ -170,7 +170,7 @@ impl ProjectViewModel for Project {
     }
 
     fn create_revert_preview_branch(
-        &mut self,
+        &self,
         head: ChangeHash,
     ) -> Result<(), CreateRevertPreviewBranchError> {
         let Some(checked_out_branch) = self.get_checked_out_branch_state() else {
@@ -247,7 +247,7 @@ impl ProjectViewModel for Project {
             .is_some_and(|i| i.heads() == &latest_dest_heads)
     }
 
-    fn confirm_preview_branch(&mut self) {
+    fn confirm_preview_branch(&self) {
         let Some(branch_state) = self.get_checked_out_branch_state() else {
             return;
         };
@@ -266,7 +266,7 @@ impl ProjectViewModel for Project {
             });
         }
     }
-    fn discard_preview_branch(&mut self) {
+    fn discard_preview_branch(&self) {
         let Some(branch_state) = self.get_checked_out_branch_state() else {
             return;
         };
@@ -429,7 +429,7 @@ impl ProjectViewModel for Project {
         self.get_branch(id.branch())
     }
 
-    fn create_branch(&mut self, name: String) {
+    fn create_branch(&self, name: String) {
         let Some(branch_state) = self.get_checked_out_branch_state() else {
             return;
         };
@@ -439,7 +439,7 @@ impl ProjectViewModel for Project {
         });
     }
 
-    fn checkout_branch(&mut self, branch: &DocumentId) {
+    fn checkout_branch(&self, branch: &DocumentId) {
         let branch = branch.clone();
         self.with_driver_blocking("Checkout branch", |driver| async move {
             driver.as_ref()?.request_checkout(&branch).await;


### PR DESCRIPTION
GodotProject now holds onto an Arc<RwLock<Project>>, and provides get_project_singleton() to allow direct access to the rust Project. This is necessary to prevent re-bind panics in the resource loader (which were always a potential hazard when it used GodotProject::get_singleton().bind()). This also allows us to always start the load in the LazyLoadToken when it is created, preventing race conditions that lead to additional panics.