### PR TITLE
Update recommended editor to 4.7.1-stable, fix writing `compatibility_minimum`

### DIFF
--- a/build.env
+++ b/build.env
@@ -9,14 +9,14 @@ THREADBARE_REF=main
 # Godot
 GODOT_REMOTE=godotengine
 GODOT_REPO=godotengine/godot.git
-GODOT_REF=5b4e0cb0fd279832bbdd69fed5354d4e5ad26f88
+GODOT_REF=a13da4feb8d8aefc283c3763d33a2f170a18d541
 
 # Godot formatters for LLVM
 GODOT_FORMATTERS_REPO=nikitalita/GodotFormatters.git
 GODOT_FORMATTERS_REF=master
 
 MINIMUM_GODOT=4.7-stable
-RECOMMENDED_GODOT=4.7-stable
+RECOMMENDED_GODOT=4.7.1-stable
 
 # Launchers below this won't be able to download the release
 MINIMUM_LAUNCHER=2.1.1

--- a/justfile
+++ b/justfile
@@ -312,6 +312,11 @@ _configure-backstitch: _make-plugin-dir
     print(f"Loaded version from Git repository: {git_describe}")
     # remove the `v` prefix if it exists and remove any trailing prerelease or build metadata
     minimum_godot = str(os.getenv("MINIMUM_GODOT")).lstrip("v").split("-")[0].split("+")[0]
+    # check if minimum_godot matches <MAJOR>.<MINOR> or <MAJOR>.<MINOR>.<PATCH>
+    split_minimum_godot = minimum_godot.split(".")
+    if (not (len(split_minimum_godot) >= 2 and len(split_minimum_godot) <= 3)) or (not all(part.isdigit() for part in split_minimum_godot)):
+        print(f"**** Minimum Godot version {minimum_godot} is not a valid version!")
+        exit(1)
 
     with open("build/backstitch/plugin.cfg", "w") as file:
         file.write(f"""[plugin]

--- a/justfile
+++ b/justfile
@@ -310,6 +310,8 @@ _configure-backstitch: _make-plugin-dir
             git_describe = git_describe[:first_index] + "-" + git_describe[first_index + 1 :].replace("-", "+")
 
     print(f"Loaded version from Git repository: {git_describe}")
+    # remove the `v` prefix if it exists and remove any trailing prerelease or build metadata
+    minimum_godot = str(os.getenv("MINIMUM_GODOT")).lstrip("v").split("-")[0].split("+")[0]
 
     with open("build/backstitch/plugin.cfg", "w") as file:
         file.write(f"""[plugin]
@@ -323,7 +325,7 @@ _configure-backstitch: _make-plugin-dir
     with open("build/backstitch/Backstitch.gdextension", "w") as file:
         file.write(f"""[configuration]
     entry_symbol = "gdext_rust_init"
-    compatibility_minimum = {os.getenv("MINIMUM_GODOT")}
+    compatibility_minimum = {minimum_godot}
     reloadable = true
 
     [libraries]


### PR DESCRIPTION
Updates recommended Godot editor to 4.7.1 (minimum is still 4.7)

`compatibility_minimum` is supposed to only take in numbers without prerelease tags (e.g. "4.7", "4.7.1"); it's only by a quirk of how Godot parses it that what we originally wrote worked.